### PR TITLE
feat: optimize update intervals for API rate limit efficiency

### DIFF
--- a/custom_components/vi_climate_devices/coordinator.py
+++ b/custom_components/vi_climate_devices/coordinator.py
@@ -42,7 +42,7 @@ class ViClimateDataUpdateCoordinator(DataUpdateCoordinator):
             hass,
             _LOGGER,
             name=f"{DOMAIN}_data",
-            update_interval=timedelta(minutes=60),
+            update_interval=timedelta(minutes=3),
         )
 
     async def _perform_discovery(self) -> None:
@@ -158,7 +158,7 @@ class ViClimateAnalyticsCoordinator(DataUpdateCoordinator):
             hass,
             _LOGGER,
             name=f"{DOMAIN}_analytics",
-            update_interval=timedelta(minutes=60),
+            update_interval=timedelta(hours=1),
         )
 
     async def _async_update_data(self) -> dict:


### PR DESCRIPTION
- Reduce data update interval from 60 to 3 minutes
- Set analytics interval to 1 hour (hours=1)
- Optimized for 2 devices (1 heating) at ~68% rate limit usage
- Total: 984 API calls/day out of 1450 limit
