### PR TITLE
fix: mask sensitive IDs in debug logs

### DIFF
--- a/custom_components/vi_climate_devices/manifest.json
+++ b/custom_components/vi_climate_devices/manifest.json
@@ -13,7 +13,7 @@
     "vi_api_client"
   ],
   "requirements": [
-    "vi_api_client @ git+https://github.com/ignazhabibi/vi_api_client.git@v1.0.0"
+    "vi_api_client @ git+https://github.com/ignazhabibi/vi_api_client.git@v1.0.1"
   ],
   "version": "1.0.1"
 }

--- a/custom_components/vi_climate_devices/sensor.py
+++ b/custom_components/vi_climate_devices/sensor.py
@@ -27,6 +27,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
+from vi_api_client.utils import mask_pii
 
 from .const import DOMAIN, IGNORED_FEATURES, TESTED_DEVICES
 from .coordinator import ViClimateAnalyticsCoordinator, ViClimateDataUpdateCoordinator
@@ -766,9 +767,10 @@ def _discover_analytics_sensors(
     if heating_devices:
         for heating_device in heating_devices:
             _LOGGER.debug(
-                "Analytics attached to device: %s (Serial: %s)",
-                heating_device.id,
-                heating_device.gateway_serial,
+                mask_pii(
+                    f"Analytics attached to device: {heating_device.id} "
+                    f"(Serial: {heating_device.gateway_serial})"
+                )
             )
             for feature_name, description in ANALYTICS_TYPES.items():
                 # Skip ignored features

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ classifiers = [
 ]
 requires-python = ">=3.11"
 dependencies = [
-    "vi_api_client @ git+https://github.com/ignazhabibi/vi_api_client.git@v1.0.0",
+    "vi_api_client @ git+https://github.com/ignazhabibi/vi_api_client.git@v1.0.1",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## Problem
Installation IDs and Gateway Serials were being logged in plaintext during DEBUG logging.

## Solution
- Upgraded `vi_api_client` to v1.0.1 to access `mask_pii()` utility
- Imported `mask_pii` from `vi_api_client.utils`
- Wrapped sensitive log statements with `mask_pii()`

## Result
**Before:**
```
Fetching devices for installation 1234567
Analytics attached to device: 0 (Serial: 1234567890123456)
```

**After:**
```
Fetching devices for installation ID: ****
Analytics attached to device: 0 (Serial: ****************)
```

## Testing
✅ All 35 tests passing
✅ PII is now masked in debug logs
✅ Linting clean