### PR TITLE
feat: optimize update intervals for better API rate limit usage

### DIFF
--- a/custom_components/vi_climate_devices/coordinator.py
+++ b/custom_components/vi_climate_devices/coordinator.py
@@ -37,7 +37,7 @@ class ViClimateDataUpdateCoordinator(DataUpdateCoordinator):
             hass,
             _LOGGER,
             name=f"{DOMAIN}_data",
-            update_interval=update_interval or timedelta(minutes=2),
+            update_interval=update_interval or timedelta(minutes=5),
         )
         self.client = client
         self._known_devices: list[Device] = []
@@ -158,7 +158,7 @@ class ViClimateAnalyticsCoordinator(DataUpdateCoordinator):
             hass,
             _LOGGER,
             name=f"{DOMAIN}_analytics",
-            update_interval=timedelta(hours=1),
+            update_interval=timedelta(minutes=15),
         )
 
     async def _async_update_data(self) -> dict:


### PR DESCRIPTION
## Problem
Current intervals cause API rate limit issues with 2+ devices:
- With 2 devices: **1464 calls/day (101%)** - exceeds limit! ❌

## Solution
Optimized update intervals based on usage analysis:
- **Main coordinator**: 2 min → **5 min**
- **Analytics coordinator**: 60 min → **15 min**

## Impact

### API Usage (2 Devices, 1 Heating)
| Metric | Before | After | Change |
|--------|--------|-------|--------|
| Main Calls/Day | 1440 | 576 | -60% |
| Analytics Calls/Day | 24 | 96 | +300% |
| **Total Calls/Day** | **1464** | **672** | **-54%** |
| **% of Limit** | **101%** ❌ | **46%** ✅ | **-55%** |

### Benefits
✅ Fixes rate limit issue (101% → 46%)  
✅ Analytics 4x more frequent (every 15 min vs hourly)  
✅ Main data still fresh (5 min is fine for heating monitoring)  
✅ 54% reserve for spikes and growth  
✅ Supports 3-4 devices comfortably  

### Trade-offs
- Main data latency: 2 min → 5 min (acceptable for HVAC)

## Testing
✅ All 35 tests passing  
✅ Linting clean  
✅ No breaking changes  

## Scaling

| Devices | Heating | Total Calls | % Limit | Status |
|---------|---------|-------------|---------|--------|
| 2 | 1 | 672 | 46% | ✅ Excellent |
| 3 | 2 | 1056 | 73% | ✅ Good |
| 4 | 2 | 1344 | 93% | ⚠️ Tight |