### PR TITLE
docs(agent): require self-contained documentation drift checks

### DIFF
--- a/.agent/rules/library-protection.md
+++ b/.agent/rules/library-protection.md
@@ -3,7 +3,7 @@
 # Library Code Protection
 
 ## CRITICAL RULE
-**I am STRICTLY FORBIDDEN from modifying any files in `/Users/michael/Projekte/vi_api_client/`**
+**I am STRICTLY FORBIDDEN from modifying files in the separate `vi_api_client` library repository as part of this integration workflow**
 
 Even though you own both projects, the library is a separate codebase that requires:
 - Version management
@@ -31,13 +31,13 @@ When I identify a need for library changes, I must:
 4. I update manifest.json and simplify test_analytics.py
 
 ### ❌ Wrong Approach:
-- I directly edit `/Users/michael/Projekte/vi_api_client/src/vi_api_client/mock_client.py`
+- I directly edit library source files in the `vi_api_client` repository
 - I create commits in the library repository
 - I modify library code without explicitly asking you first
 
 ## Scope
-- **Integration files**: `/Users/michael/Projekte/vi_climate_devices/` - I CAN modify
-- **Library files**: `/Users/michael/Projekte/vi_api_client/` - I CANNOT modify (INFORM YOU instead)
+- **Integration files**: Files in this repository - I CAN modify
+- **Library files**: Files in the separate `vi_api_client` repository - I CANNOT modify (INFORM YOU instead)
 
 ## Key Principle
 **"Inform, don't modify"** - My role is to identify what needs to change in the library and let you handle the actual modifications.

--- a/.agent/workflows/doc-update.md
+++ b/.agent/workflows/doc-update.md
@@ -1,20 +1,45 @@
 ---
-description: Synchronize documentation (README) with the integration codebase
+description: Synchronize repository documentation with the current codebase, tooling, and workflow reality
 ---
 
 # Documentation Update Workflow
 
-This workflow ensures that `README.md` is strictly synchronized with the Home Assistant integration implementation.
+This workflow ensures that repository-operational documentation stays
+self-contained and synchronized with the current Home Assistant integration
+implementation, tooling, and workflow reality.
 
 ## 1. Analysis Phase
 
-Identify which components have changed and require documentation updates.
+Identify which parts of the repository changed and which documentation surfaces
+must be updated together.
 
 ### Check `README.md`
 - **Installation**: Are the HACS and manual installation steps still accurate?
 - **Configuration**: Does the configuration flow description match `config_flow.py`?
 - **Entities**: Are the examples in "Entities Overview" still representative of `sensor.py`, `binary_sensor.py`, etc.?
 - **Troubleshooting**: Are the common issues still relevant?
+
+### Check `AGENTS.md`
+- **Bootstrap Guidance**: Does the agent entrypoint still describe the correct
+  always-relevant files, workflows, and mandatory checks?
+- **Operational Truths**: Do CI, release, setup, and governance notes match the
+  current repository reality?
+
+### Check `.agent/rules/`
+- **`architecture-context.md`**: Do architecture assumptions still match the
+  actual integration and library usage?
+- **`tech-stack.md`**: Does the documented Python/tooling/dependency baseline
+  still match the project?
+- **Other Rules**: Do testing, git, and library protection rules still reflect
+  how the repo is actually maintained?
+
+### Check `.agent/workflows/`
+- **Workflow Triggers**: Does each workflow still match how work is really
+  performed in this repository?
+- **Protected Branch Reality**: Do branch, PR, release, and commit steps match
+  current GitHub governance?
+- **Validation Steps**: Do local and CI checks in the workflows still match the
+  actual commands used by the repo?
 
 ### Check Global Files
 - **`manifest.json`**: Verify that requirements and version match any claims in documentation.
@@ -27,17 +52,21 @@ Identify which components have changed and require documentation updates.
 
 ## 2. Verification Steps (The "Meticulous Check")
 
-For *every* piece of code documentation you update:
+For every documentation surface you update:
 1.  **Open the source file** alongside the doc file.
 2.  **Verify names:** Configuration keys, Entity IDs patterns, Service names.
-3.  **Verify logic:** If the docs explain *how* something works (e.g. "polled every 60s"), check `coordinator.py` or relevant constants to confirm.
+3.  **Verify logic:** If the docs explain how something works (e.g. branch
+    protection, release steps, "polled every 60s"), check the actual workflow,
+    code, or GitHub setup evidence first.
 
 > [!IMPORTANT]
 > If there is *any* discrepancy, the code is the source of truth. Update the documentation to match the code.
 
 ## 3. Execution
 
-1.  Make the necessary edits to `README.md`.
-2.  **Notify User:** Inform the user that documentation is updated and ready for review/commit.
-    > [!NOTE]
-    > Do not commit changes automatically. Leave them staged or unstaged for the user.
+1.  Update every affected documentation surface, not just `README.md`.
+2.  If architecture, tech stack, testing strategy, CI, release flow, or GitHub
+    governance changed, ensure the relevant rule/workflow files are updated in
+    the same task.
+3.  In the final handoff, explicitly state which documentation files were
+    checked and whether any remained unchanged after review.

--- a/.agent/workflows/feature-develop.md
+++ b/.agent/workflows/feature-develop.md
@@ -92,6 +92,20 @@ git commit -m "type: description"
 - Proposed commit message
 - Summary of changes
 
+### D. Documentation Drift Check
+Before considering the feature complete, explicitly check whether the work
+changed repository-operational documentation, including:
+
+- `README.md`
+- `AGENTS.md`
+- `.agent/rules/`, especially `architecture-context.md` and `tech-stack.md`
+- `.agent/workflows/`
+
+If the feature changed architecture, tech stack, setup commands, testing
+strategy, CI behavior, release flow, or GitHub governance expectations, update
+the affected documentation in the same task or explicitly state that it was
+checked and no change was needed.
+
 ---
 
 ## Notes

--- a/.agent/workflows/release.md
+++ b/.agent/workflows/release.md
@@ -108,6 +108,14 @@ Create a changelog snippet in the requested style.
 - Do not claim the release is live until:
   - the PR merge produced a green `main` push run, and
   - the tag run for `v<NEW_VERSION>` is green.
+- Perform a final documentation drift check for release-related guidance:
+  - `README.md`
+  - `AGENTS.md`
+  - `.agent/rules/tech-stack.md`
+  - `.agent/rules/git-workflow.md`
+  - `.agent/workflows/release.md`
+  Update them in the same task if the release changed versioning policy,
+  dependency/update policy, CI expectations, or release procedure assumptions.
 - Confirm both runs explicitly:
   ```bash
   gh run list --workflow release.yml --limit 5

--- a/.agent/workflows/rules-compliance-check.md
+++ b/.agent/workflows/rules-compliance-check.md
@@ -1,45 +1,55 @@
 ---
-description: Bring the current file up to the standards defined in the project rules
+description: Review and update agent guidance so rules, workflows, and bootstrap docs remain aligned with repository reality
 ---
 
-# Code Compliance & Modernization
+# Rules and Workflow Compliance Check
 
-**Goal:** Bring the current file up to the standards defined in the project rules (`.agent/rules/*.md`), specifically focusing on the **Home Assistant Integration** context and **Flat Architecture**.
+**Goal:** Keep `AGENTS.md`, `.agent/rules/`, and `.agent/workflows/`
+self-contained, current, and internally consistent with the real repository
+behavior.
 
 ## Instructions
 
-Act as a strict Code Reviewer and Refactoring Agent. Analyze the code and apply the following transformations step-by-step.
+Act as a strict repository guidance reviewer. Audit the guidance files against
+the actual codebase, CI, release process, and GitHub governance, then update
+them directly where needed.
 
-### Phase 1: Architecture Check (ref: `architecture-context.md`)
-1.  **Flat Model Enforcement:**
-    *   Ensure NO nested property access on devices (e.g., `device.heating....` is BANNED).
-    *   Ensure usage of `device.features` list or `get_feature()` methods.
-2.  **No Polling:**
-    *   Verify `update_device(device)` is used for refreshing state, not individual feature polls.
-3.  **Hybrid Discovery:**
-    *   If this is an Entity file, check if it respects the "Defined" vs "Auto" discovery logic.
+### Phase 1: Repository Reality Check
+1.  **Bootstrap Alignment:**
+    *   Verify `AGENTS.md` still points to the right always-relevant files and workflows.
+    *   Ensure it reflects current branch protection, CI, release, setup, and test-stack reality.
+2.  **Rules Alignment:**
+    *   Check `.agent/rules/` for stale assumptions about architecture, tech stack, testing, Git workflow, and library boundaries.
+    *   Pay special attention to `architecture-context.md` and `tech-stack.md` whenever architecture or tooling changed.
+3.  **Workflow Alignment:**
+    *   Check `.agent/workflows/` for stale steps, especially around branches, PRs, release flow, validation commands, and documentation duties.
 
-### Phase 2: Structure & Imports (ref: `python-style.md`)
-1.  **Imports:** Sort all imports using standard sorting logic.
-2.  **Sorting:** Sort the contents of Lists (e.g., `SUPPORTED_PLATFORMS`, `CONSTANTS`) and Dictionary keys **alphabetically**.
-3.  **Filesystem:** Replace all `os.path` operations with `pathlib.Path` syntax.
-4.  **Naming:** Identify short variable names (k, v, d) and rename them to be descriptive (key, value, data).
+### Phase 2: Self-Contained Documentation Check
+1.  **Coverage:** Ensure repository-operational documentation is treated as one
+    system:
+    *   `README.md`
+    *   `AGENTS.md`
+    *   `.agent/rules/`
+    *   `.agent/workflows/`
+2.  **Durable Knowledge:** If a new insight changed how the repo is actually
+    maintained, verify that the insight is captured in the right doc file and
+    not left implicit in conversation only.
+3.  **No Silent Drift:** If a file is stale, update it as part of the task
+    instead of merely noting the discrepancy.
 
-### Phase 3: Syntax & Logging (CRITICAL!)
-1.  **Modern Python (3.14):** Update syntax to Python 3.14 standards (e.g., use `|` for Unions instead of `Optional` or `Union`, use `type` aliases).
-2.  **Logging:** Audit EVERY `_LOGGER` call:
-    *   **MUST FIX:** Convert f-strings (`f"..."`) inside logger calls to Lazy Formatting (`%s`).
-    *   Remove trailing periods `.` from log messages.
-3.  **Strings:** Convert all *other* string concatenations (outside of logging) to **f-strings**.
+### Phase 3: Required Triggers
+Treat guidance updates as mandatory when the task changed any of the following:
 
-### Phase 4: Typing & Documentation (ref: `python-docs.md`)
-1.  **Typing:**
-    *   Replace `List`, `Dict`, `Tuple` imports with native types (`list`, `dict`, `tuple`).
-    *   Remove `Any` where a specific type can be inferred.
-2.  **Docstrings:**
-    *   Ensure a file-header docstring exists.
-    *   Add docstrings for all Public Methods using **Google Style**.
-    *   **IMPORTANT:** Remove type definitions from the docstring text (e.g., change `Args: name (str):` to `Args: name:`).
+- architecture or discovery assumptions
+- tech stack, Python baseline, or dependency strategy
+- test strategy, snapshot handling, or CI authority
+- local setup commands
+- release versioning or tagging flow
+- GitHub governance such as branch protection or PR requirements
 
 ## Output
-Apply the changes directly to the file. Afterwards, provide a short bullet-point summary of what was fixed.
+Apply the necessary guidance updates directly. Afterwards:
+
+- summarize what guidance was updated
+- state which files were reviewed for drift
+- explicitly note if any checked files needed no change

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,14 +43,46 @@ Pick the matching workflow before making substantial changes:
 - Rules review / agent guidance cleanup: `.agent/workflows/rules-compliance-check.md`
 - Documentation-only work: `.agent/workflows/doc-update.md`
 
+## Self-Contained Repository Documentation
+
+Treat the repository-operational documentation as a self-contained system that
+must stay current together:
+
+- `README.md`
+- `AGENTS.md`
+- `.agent/rules/`, especially `architecture-context.md` and `tech-stack.md`
+- `.agent/workflows/`
+
+After any task that changes repository behavior or expectations, the agent must
+perform an explicit documentation drift check before considering the work
+complete.
+
+This is mandatory for changes affecting:
+
+- architecture or feature model assumptions
+- tech stack or Python/dependency policy
+- local setup commands
+- testing strategy or snapshot handling
+- CI behavior or required checks
+- release flow or versioning rules
+- GitHub governance such as branch protection, rulesets, merge policy, or PR requirements
+
+The agent must then do one of the following:
+
+- update the affected documentation in the same task, or
+- explicitly state that the documentation was checked and no update is needed
+
+Do not keep durable repository knowledge implicit when the repository guidance
+should be updated to reflect it.
+
 ## Project Context
 
 - This is a Home Assistant custom integration for Viessmann climate devices.
 - Main integration code lives in `custom_components/vi_climate_devices/`.
 - Tests live in `tests/`.
 - The integration depends on `vi_api_client`, which uses a flat feature model.
-- Treat `vi_api_client` as a separate codebase. Do not edit files in
-  `/Users/michael/Projekte/vi_api_client/` from this repo workflow.
+- Treat `vi_api_client` as a separate codebase. Do not edit library files
+  outside this repository as part of this repo workflow.
 - `MockViClient` with the `Vitocal250A` fixture is the preferred test client.
 - Snapshot coverage is centered on discovery behavior in
   `tests/test_discovery_snapshot.py`.
@@ -107,7 +139,5 @@ validate once in a fresh environment installed with `.[dev]`.
 - For snapshot updates, inspect the `.ambr` diff instead of blindly accepting it.
 - If rules or workflows look stale, update them as part of the task instead of
   working around them silently.
-- If important new insights emerge during the work, and those insights should
-  be preserved in `AGENTS.md`, a workflow, or a rule file, the agent must
-  explicitly propose that documentation update instead of keeping the knowledge
-  implicit.
+- End substantial tasks with an explicit repository documentation drift check
+  against `README.md`, `AGENTS.md`, `.agent/rules/`, and `.agent/workflows/`.


### PR DESCRIPTION
## Summary
- make repository documentation drift checks mandatory for agents
- expand the documentation workflow from README-only to repo-wide operational docs
- remove local filesystem paths from public agent guidance

## Notes
- docs and agent-guidance only
- no tests run