### PR TITLE
add HA lifecycle coverage and clarify commit workflow

### DIFF
--- a/.agent/rules/git-workflow.md
+++ b/.agent/rules/git-workflow.md
@@ -26,6 +26,9 @@ Strict guidelines for version control and feature development.
 2. **Local Tests**: Run `python -m pytest -q` frequently.
 3. **Local Lint**: Run `ruff check .` and `ruff format --check .` before every commit.
 4. **Commit**: `git commit -m "type: description"` (Conventional Commits).
+   - Preferred format in this repository is `type: description`.
+   - Use `feat`, `fix`, `refactor`, `docs`, `test`, or `chore`.
+   - Do not require a scope by default.
 
 ### C. Submit (The Gatekeeper)
 1. `git push -u origin feature/<name>`

--- a/.agent/workflows/pr-submit.md
+++ b/.agent/workflows/pr-submit.md
@@ -40,8 +40,12 @@ The agent must first verify:
 ## 2. Commit (Agent)
 
 1.  **Stage**: `git add .`
-2.  **Commit**: Generate a comprehensive commit message `type(scope): description`.
+2.  **Commit**: Follow `.agent/rules/git-workflow.md` and generate a commit
+    message in the format `type: description`.
     - `feat`, `fix`, `refactor`, `docs`, `test`, `chore`.
+    - Do **not** add a required scope unless the user explicitly wants one.
+    - Examples: `feat: add analytics sensors`, `fix: handle token refresh`,
+      `test: add lifecycle and oauth coverage`.
     - Message should be under 50 chars ideally.
 
 ## 3. Push & PR (Agent)

--- a/custom_components/vi_climate_devices/coordinator.py
+++ b/custom_components/vi_climate_devices/coordinator.py
@@ -129,6 +129,8 @@ class ViClimateDataUpdateCoordinator(DataUpdateCoordinator):
 
             return updated_data
 
+        except ConfigEntryAuthFailed:
+            raise
         except ViAuthError as err:
             raise ConfigEntryAuthFailed(f"Authentication failed: {err}") from err
         except Exception as exception:

--- a/tests/test_application_credentials.py
+++ b/tests/test_application_credentials.py
@@ -1,0 +1,56 @@
+"""Tests for application credentials helpers."""
+
+import pytest
+from homeassistant.components.application_credentials import ClientCredential
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.config_entry_oauth2_flow import (
+    LocalOAuth2ImplementationWithPkce,
+)
+from vi_api_client.const import ENDPOINT_AUTHORIZE, ENDPOINT_TOKEN
+
+from custom_components.vi_climate_devices.application_credentials import (
+    async_get_auth_implementation,
+    async_get_authorization_server,
+)
+
+
+@pytest.mark.asyncio
+async def test_async_get_authorization_server_uses_viessmann_endpoints(
+    hass: HomeAssistant,
+) -> None:
+    """Test the authorization server points to the Viessmann OAuth endpoints."""
+    # Arrange: Use the Home Assistant test instance as-is.
+
+    # Act: Build the advertised authorization server metadata.
+    server = await async_get_authorization_server(hass)
+
+    # Assert: The returned endpoints match the Viessmann library constants.
+    assert str(server.authorize_url) == ENDPOINT_AUTHORIZE
+    assert str(server.token_url) == ENDPOINT_TOKEN
+
+
+@pytest.mark.asyncio
+async def test_async_get_auth_implementation_returns_pkce_implementation(
+    hass: HomeAssistant,
+) -> None:
+    """Test the credentials helper builds a PKCE-based local OAuth implementation."""
+    # Arrange: Provide stored Home Assistant application credentials.
+    credential = ClientCredential(
+        client_id="client-id",
+        client_secret="client-secret",
+        name="Viessmann",
+    )
+
+    # Act: Create the OAuth implementation from the stored credentials.
+    implementation = await async_get_auth_implementation(
+        hass,
+        "vi_climate_devices",
+        credential,
+    )
+
+    # Assert: The integration uses a PKCE-capable local OAuth implementation.
+    assert isinstance(implementation, LocalOAuth2ImplementationWithPkce)
+    assert implementation.client_id == "client-id"
+    assert implementation.client_secret == "client-secret"
+    assert implementation.authorize_url == ENDPOINT_AUTHORIZE
+    assert implementation.token_url == ENDPOINT_TOKEN

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -1,0 +1,86 @@
+"""Tests for the OAuth config flow wrapper."""
+
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+from homeassistant import config_entries
+from homeassistant.core import HomeAssistant
+from homeassistant.data_entry_flow import FlowResultType
+from homeassistant.helpers import config_entry_oauth2_flow
+from vi_api_client.const import DEFAULT_SCOPES
+from yarl import URL
+
+from custom_components.vi_climate_devices.config_flow import OAuth2FlowHandler
+from custom_components.vi_climate_devices.const import DOMAIN
+
+
+class FakeOAuthImplementation(config_entry_oauth2_flow.AbstractOAuth2Implementation):
+    """Minimal OAuth implementation for config flow tests."""
+
+    @property
+    def name(self) -> str:
+        """Return a friendly implementation name."""
+        return "Fake OAuth"
+
+    @property
+    def domain(self) -> str:
+        """Return the provider domain."""
+        return "fake-provider"
+
+    async def async_generate_authorize_url(self, flow_id: str) -> str:
+        """Return a deterministic authorize URL for the flow."""
+        return f"https://example.com/authorize?existing=1&flow_id={flow_id}"
+
+    async def async_resolve_external_data(self, external_data: Any) -> dict[str, Any]:
+        """Resolve external OAuth data."""
+        return {"access_token": "token", "expires_in": 3600}
+
+    async def _async_refresh_token(self, token: dict[str, Any]) -> dict[str, Any]:
+        """Return the unmodified token payload."""
+        return token
+
+
+@pytest.mark.asyncio
+async def test_flow_handler_exposes_viessmann_scope() -> None:
+    """Test the flow handler appends the Viessmann OAuth scopes to the authorize URL."""
+    # Arrange: Instantiate the lightweight OAuth flow wrapper.
+    flow_handler = OAuth2FlowHandler()
+
+    # Act: Read the extra authorize data from the flow.
+    authorize_data = flow_handler.extra_authorize_data
+
+    # Assert: The flow publishes the library-defined Viessmann scope string.
+    assert authorize_data == {"scope": DEFAULT_SCOPES}
+
+
+@pytest.mark.asyncio
+async def test_user_flow_shows_picker_and_starts_external_step(
+    hass: HomeAssistant,
+) -> None:
+    """Test the user flow offers the implementation picker and starts OAuth auth."""
+    # Arrange: Register one fake implementation through the OAuth helper layer.
+    implementation = FakeOAuthImplementation()
+
+    with patch(
+        "homeassistant.helpers.config_entry_oauth2_flow.async_get_implementations",
+        return_value={implementation.domain: implementation},
+    ):
+        # Act: Start the flow and choose the fake implementation.
+        start_result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": config_entries.SOURCE_USER},
+        )
+        auth_result = await hass.config_entries.flow.async_configure(
+            start_result["flow_id"],
+            {"implementation": implementation.domain},
+        )
+
+    # Assert: The flow shows the picker first and then redirects to OAuth auth.
+    assert start_result["type"] is FlowResultType.FORM
+    assert start_result["step_id"] == "pick_implementation"
+    assert auth_result["type"] is FlowResultType.EXTERNAL_STEP
+    assert auth_result["step_id"] == "auth"
+    authorize_url = URL(auth_result["url"])
+    assert authorize_url.query["existing"] == "1"
+    assert authorize_url.query["scope"] == DEFAULT_SCOPES

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -1,0 +1,118 @@
+"""Tests for coordinator discovery and refresh behavior."""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import ConfigEntryAuthFailed
+from homeassistant.helpers.update_coordinator import UpdateFailed
+from vi_api_client import Device, Feature, ViAuthError
+
+from custom_components.vi_climate_devices.coordinator import (
+    ViClimateDataUpdateCoordinator,
+)
+
+
+def _build_device(
+    *,
+    device_id: str,
+    gateway_serial: str,
+    model_id: str = "Vitocal250A",
+) -> Device:
+    """Create a minimal Viessmann device for coordinator tests."""
+    return Device(
+        id=device_id,
+        gateway_serial=gateway_serial,
+        installation_id="installation-1",
+        model_id=model_id,
+        device_type="heating",
+        status="online",
+        features=[
+            Feature(
+                name="heating.sensors.temperature.outside",
+                value=12.2,
+                unit="celsius",
+                is_enabled=True,
+                is_ready=True,
+            )
+        ],
+    )
+
+
+@pytest.mark.asyncio
+async def test_data_coordinator_raises_when_no_installations_exist(
+    hass: HomeAssistant, mock_client
+) -> None:
+    """Test discovery raises UpdateFailed when the account has no installations."""
+    # Arrange: Return an empty installation list from the Viessmann client.
+    mock_client.get_installations = AsyncMock(return_value=[])
+    coordinator = ViClimateDataUpdateCoordinator(hass, mock_client)
+
+    # Act and Assert: The first refresh aborts with a clear update failure.
+    with pytest.raises(UpdateFailed, match="No installations found"):
+        await coordinator._async_update_data()
+
+
+@pytest.mark.asyncio
+async def test_data_coordinator_discovers_devices_and_filters_ignored_ids(
+    hass: HomeAssistant, mock_client
+) -> None:
+    """Test discovery keeps regular devices and drops configured ignored device ids."""
+    # Arrange: Return one real device and one ignored gateway pseudo-device.
+    active_device = _build_device(device_id="device-0", gateway_serial="gw-main")
+    ignored_device = _build_device(
+        device_id="gateway",
+        gateway_serial="gw-ignored",
+        model_id="Gateway",
+    )
+    mock_client.get_installations = AsyncMock(
+        return_value=[SimpleNamespace(id="installation-1")]
+    )
+    mock_client.get_full_installation_status = AsyncMock(
+        return_value=[active_device, ignored_device]
+    )
+    mock_client.update_device = AsyncMock(return_value=active_device)
+    coordinator = ViClimateDataUpdateCoordinator(hass, mock_client)
+
+    # Act: Run the first coordinator refresh with discovery enabled.
+    result = await coordinator._async_update_data()
+
+    # Assert: Only the real device survives discovery and is tracked for updates.
+    assert result == {"gw-main_device-0": active_device}
+    assert coordinator._known_devices == [active_device]
+
+
+@pytest.mark.asyncio
+async def test_data_coordinator_keeps_last_device_state_when_refresh_fails(
+    hass: HomeAssistant, mock_client
+) -> None:
+    """Test refresh falls back to the previous immutable device when one update fails."""
+    # Arrange: Seed one known device and make its refresh raise a transient error.
+    known_device = _build_device(device_id="device-0", gateway_serial="gw-main")
+    mock_client.update_device = AsyncMock(side_effect=RuntimeError("device offline"))
+    coordinator = ViClimateDataUpdateCoordinator(hass, mock_client)
+    coordinator._known_devices = [known_device]
+
+    # Act: Refresh the coordinator with the failing device update.
+    result = await coordinator._async_update_data()
+
+    # Assert: The previous device object stays available in coordinator data.
+    assert result == {"gw-main_device-0": known_device}
+    assert coordinator._known_devices == [known_device]
+
+
+@pytest.mark.asyncio
+async def test_data_coordinator_raises_reauth_when_device_update_loses_auth(
+    hass: HomeAssistant, mock_client
+) -> None:
+    """Test refresh raises ConfigEntryAuthFailed when device polling loses auth."""
+    # Arrange: Seed one known device and make the update raise ViAuthError.
+    known_device = _build_device(device_id="device-0", gateway_serial="gw-main")
+    mock_client.update_device = AsyncMock(side_effect=ViAuthError("token expired"))
+    coordinator = ViClimateDataUpdateCoordinator(hass, mock_client)
+    coordinator._known_devices = [known_device]
+
+    # Act and Assert: The auth failure is escalated to Home Assistant reauth.
+    with pytest.raises(ConfigEntryAuthFailed, match="token expired"):
+        await coordinator._async_update_data()

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,0 +1,214 @@
+"""Tests for integration setup, unload, and auth bridge behavior."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from homeassistant.core import HomeAssistant
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+from vi_api_client.auth import ViAuthError
+
+from custom_components.vi_climate_devices import (
+    PLATFORMS,
+    HAAuth,
+    async_setup_entry,
+    async_unload_entry,
+)
+from custom_components.vi_climate_devices.const import DOMAIN
+
+
+def _build_entry() -> MockConfigEntry:
+    """Create a config entry with OAuth token data."""
+    return MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            "token": {
+                "access_token": "initial-token",
+                "expires_at": 3_800_000_000,
+                "refresh_token": "refresh-token",
+                "token_type": "Bearer",
+            }
+        },
+    )
+
+
+@pytest.mark.asyncio
+async def test_async_setup_entry_returns_false_when_token_validation_fails(
+    hass: HomeAssistant,
+) -> None:
+    """Test setup aborts early when Home Assistant cannot validate the token."""
+    # Arrange: Register a config entry and force token validation to fail.
+    entry = _build_entry()
+    entry.add_to_hass(hass)
+
+    with (
+        patch(
+            "homeassistant.helpers.config_entry_oauth2_flow.async_get_config_entry_implementation",
+            return_value=MagicMock(),
+        ),
+        patch(
+            "homeassistant.helpers.config_entry_oauth2_flow.OAuth2Session.async_ensure_token_valid",
+            side_effect=RuntimeError("token refresh failed"),
+        ),
+    ):
+        # Act: Attempt to set up the integration entry.
+        result = await async_setup_entry(hass, entry)
+
+    # Assert: Setup fails without storing runtime data for the entry.
+    assert result is False
+    assert hass.data[DOMAIN] == {}
+
+
+@pytest.mark.asyncio
+async def test_async_setup_entry_keeps_loading_when_analytics_refresh_fails(
+    hass: HomeAssistant,
+) -> None:
+    """Test setup keeps runtime data when only the initial analytics refresh fails."""
+    # Arrange: Build entry, coordinators, and forward-setup stub for the success path.
+    entry = _build_entry()
+    entry.add_to_hass(hass)
+    client = MagicMock()
+    auth_bridge = MagicMock()
+    main_coordinator = MagicMock()
+    main_coordinator.async_config_entry_first_refresh = AsyncMock(return_value=None)
+    analytics_coordinator = MagicMock()
+    analytics_coordinator.async_config_entry_first_refresh = AsyncMock(
+        side_effect=RuntimeError("analytics unavailable")
+    )
+    forward_entry_setups = AsyncMock(return_value=None)
+
+    with (
+        patch(
+            "homeassistant.helpers.config_entry_oauth2_flow.async_get_config_entry_implementation",
+            return_value=MagicMock(),
+        ),
+        patch(
+            "homeassistant.helpers.config_entry_oauth2_flow.OAuth2Session.async_ensure_token_valid",
+            return_value=None,
+        ),
+        patch(
+            "custom_components.vi_climate_devices.HAAuth",
+            return_value=auth_bridge,
+        ),
+        patch(
+            "custom_components.vi_climate_devices.ViessmannClient",
+            return_value=client,
+        ) as mock_client_class,
+        patch(
+            "custom_components.vi_climate_devices.ViClimateDataUpdateCoordinator",
+            return_value=main_coordinator,
+        ),
+        patch(
+            "custom_components.vi_climate_devices.ViClimateAnalyticsCoordinator",
+            return_value=analytics_coordinator,
+        ),
+        patch.object(
+            hass.config_entries,
+            "async_forward_entry_setups",
+            forward_entry_setups,
+        ),
+    ):
+        # Act: Set up the integration despite the analytics warm-up failure.
+        result = await async_setup_entry(hass, entry)
+
+    # Assert: Setup succeeds, stores both coordinators, and forwards all platforms.
+    assert result is True
+    assert hass.data[DOMAIN][entry.entry_id] == {
+        "data": main_coordinator,
+        "analytics": analytics_coordinator,
+    }
+    mock_client_class.assert_called_once_with(auth=auth_bridge)
+    main_coordinator.async_config_entry_first_refresh.assert_awaited_once()
+    analytics_coordinator.async_config_entry_first_refresh.assert_awaited_once()
+    forward_entry_setups.assert_awaited_once_with(entry, PLATFORMS)
+
+
+@pytest.mark.asyncio
+async def test_async_unload_entry_removes_runtime_data_after_platform_unload(
+    hass: HomeAssistant,
+) -> None:
+    """Test unloading removes stored runtime data when platform unload succeeds."""
+    # Arrange: Seed runtime data and make platform unload succeed.
+    entry = _build_entry()
+    hass.data.setdefault(DOMAIN, {})[entry.entry_id] = {"data": MagicMock()}
+    unload_platforms = AsyncMock(return_value=True)
+
+    with patch.object(hass.config_entries, "async_unload_platforms", unload_platforms):
+        # Act: Unload the config entry.
+        result = await async_unload_entry(hass, entry)
+
+    # Assert: The entry unloads cleanly and runtime data is removed.
+    assert result is True
+    assert entry.entry_id not in hass.data[DOMAIN]
+    unload_platforms.assert_awaited_once_with(entry, PLATFORMS)
+
+
+@pytest.mark.asyncio
+async def test_async_unload_entry_keeps_runtime_data_when_platform_unload_fails(
+    hass: HomeAssistant,
+) -> None:
+    """Test unloading keeps runtime data intact when platform unload fails."""
+    # Arrange: Seed runtime data and make platform unload fail.
+    entry = _build_entry()
+    runtime_data = {"data": MagicMock()}
+    hass.data.setdefault(DOMAIN, {})[entry.entry_id] = runtime_data
+    unload_platforms = AsyncMock(return_value=False)
+
+    with patch.object(hass.config_entries, "async_unload_platforms", unload_platforms):
+        # Act: Attempt to unload the config entry.
+        result = await async_unload_entry(hass, entry)
+
+    # Assert: The failure is reported and runtime data stays registered.
+    assert result is False
+    assert hass.data[DOMAIN][entry.entry_id] is runtime_data
+    unload_platforms.assert_awaited_once_with(entry, PLATFORMS)
+
+
+@pytest.mark.asyncio
+async def test_haauth_async_get_access_token_returns_refreshed_token(
+    hass: HomeAssistant,
+) -> None:
+    """Test the auth bridge returns the refreshed Home Assistant access token."""
+    # Arrange: Provide a Home Assistant OAuth session with a valid token payload.
+    oauth_session = MagicMock()
+    oauth_session.hass = hass
+    oauth_session.token = {"access_token": "fresh-token"}
+    oauth_session.async_ensure_token_valid = AsyncMock(return_value=None)
+    websession = object()
+
+    with patch(
+        "custom_components.vi_climate_devices.async_get_clientsession",
+        return_value=websession,
+    ):
+        auth_bridge = HAAuth(oauth_session)
+
+    # Act: Request the access token through the auth bridge.
+    token = await auth_bridge.async_get_access_token()
+
+    # Assert: The bridge reuses the refreshed token and cached aiohttp session.
+    assert token == "fresh-token"
+    assert auth_bridge.websession is websession
+    oauth_session.async_ensure_token_valid.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_haauth_async_get_access_token_wraps_refresh_errors(
+    hass: HomeAssistant,
+) -> None:
+    """Test the auth bridge wraps Home Assistant token refresh errors for the client."""
+    # Arrange: Provide a session that fails during token refresh.
+    oauth_session = MagicMock()
+    oauth_session.hass = hass
+    oauth_session.token = {"access_token": "stale-token"}
+    oauth_session.async_ensure_token_valid = AsyncMock(
+        side_effect=RuntimeError("refresh exploded")
+    )
+
+    with patch(
+        "custom_components.vi_climate_devices.async_get_clientsession",
+        return_value=object(),
+    ):
+        auth_bridge = HAAuth(oauth_session)
+
+    # Act and Assert: The client receives a ViAuthError with the original message.
+    with pytest.raises(ViAuthError, match="refresh exploded"):
+        await auth_bridge.async_get_access_token()


### PR DESCRIPTION
## What changed
Added focused Home Assistant integration coverage for lifecycle, coordinator, OAuth config flow, and application credentials behavior.

Also clarified the repository commit-message workflow so `pr-submit` and `git-workflow` consistently use the repository-preferred `type: description` format without requiring a scope.

## Why
The existing suite covered entity behavior and discovery well, but left important HA-specific paths under-tested: setup/unload lifecycle, reauth propagation, coordinator discovery fallbacks, and OAuth wrapper behavior.

The repository guidance also had conflicting commit-message expectations between workflow documents, which led to avoidable inconsistency.

## Impact
This improves regression safety around integration startup, coordinator refresh failures, and OAuth-related setup paths.

It also makes the agent workflow documentation consistent for future PRs and commits.

## Root cause
These runtime paths were either only indirectly exercised or not covered at all, which allowed a real reauth propagation bug in the coordinator to go unnoticed.

Separately, the workflow docs diverged on whether commit scopes were required.

## Validation
- `ruff check .`
- `ruff format --check .`
- `pytest -q`
