### PR TITLE
clarify PR and release messaging

### DIFF
--- a/.agent/workflows/pr-submit.md
+++ b/.agent/workflows/pr-submit.md
@@ -55,11 +55,25 @@ The agent must first verify:
     git push -u origin HEAD
     ```
 
-2.  **Create PR**:
+2.  **Prepare PR Title & Body**:
+    - **PR Title**: Write a user-facing summary of the full branch in plain
+      language, without prefixes like `[codex]`.
+    - **PR Body**: Summarize the whole PR, not the individual commits. Use this
+      structure:
+      - `What changed`
+      - `Why`
+      - `Impact`
+      - `Validation`
+    - Because this repository uses squash merge, the PR title should read well
+      as the final commit title on `main`.
+
+3.  **Create PR**:
     *   **Option A (Best)**: If `gh` CLI is installed:
         ```bash
-        gh pr create --fill --web
+        gh pr create --title "<PR_TITLE>" --body-file <PR_BODY_FILE> --web
         ```
+        Do not rely on `--fill` alone when it would copy commit wording that is
+        too narrow or too technical for the full PR.
     *   **Option B (Fallback)**: If `gh` fails or is missing, **construct and display the URL** for the user:
         `https://github.com/ignazhabibi/vi_climate_devices/pull/new/<BRANCH_NAME>`
 

--- a/.agent/workflows/release.md
+++ b/.agent/workflows/release.md
@@ -49,27 +49,38 @@ This workflow guides the agent to create a semantic release for the Home Assista
     -   Propose the New Version.
     -   **WAIT for Confirmation**.
 
-## 3. Generate Changelog
+## 3. Message Hierarchy
+Use different message styles for commits, pull requests, and releases.
+
+- **Commit messages**: Atomic and technical. Follow the repository format
+  `type: description`.
+- **PR titles and bodies**: Summarize the full branch for reviewers.
+- **Release notes**: Summarize multiple merged PRs for users. Favor user-facing
+  outcomes over raw commit history.
+
+## 4. Generate Changelog
 Create a changelog snippet in the requested style.
-**IMPORTANT:** Do NOT summarize. Use the exact commit scope and message from `git log`. Include the commit hash.
+**IMPORTANT:** Do summarize at the release level. Group related merged work into
+user-facing entries instead of replaying raw commit subjects line by line.
+Reference PRs or commits when useful, but do not depend on scopes being present.
 
 ```markdown
 # Changelog
 
 ## Breaking Changes 🚨
-<commit_hash> <scope>: <message> (BC)
+<summary> (PR #xx, commit <hash>) (BC)
 
 ## New Features 💫
-<commit_hash> <scope>: <message>
+<summary> (PR #xx, commit <hash>)
 
 ## Bug Fixes 🐞
-<commit_hash> <scope>: <message>
+<summary> (PR #xx, commit <hash>)
 
 ## Other Changes ☀️
-<commit_hash> <scope>: <message>
+<summary> (PR #xx, commit <hash>)
 ```
 
-## 4. Execution
+## 5. Execution
 1.  **Create Release Branch**:
     ```bash
     git checkout -b release/v<NEW_VERSION>
@@ -82,7 +93,7 @@ Create a changelog snippet in the requested style.
 3.  **Commit**:
     ```bash
     git add custom_components/vi_climate_devices/manifest.json pyproject.toml
-    git commit -m "chore(release): bump version to <NEW_VERSION>"
+    git commit -m "chore: bump version to <NEW_VERSION>"
     ```
 4.  **Push Release Branch & PR**:
     ```bash
@@ -103,7 +114,7 @@ Create a changelog snippet in the requested style.
     git push origin v<NEW_VERSION>
     ```
 
-## 5. Post-Release
+## 6. Post-Release
 - GitHub Actions (if configured) will automatically build and publish the release.
 - Do not claim the release is live until:
   - the PR merge produced a green `main` push run, and


### PR DESCRIPTION
## What changed
Clarified how this repository distinguishes commit messages, PR messages, and release notes.

Updated the PR submission workflow so pull requests use an explicit title and a reviewer-oriented body instead of relying on commit text alone.

Updated the release workflow so release notes are written as user-facing summaries across multiple PRs and so release bump commits follow the repository-standard `type: description` format.

## Why
The repository already had a clear commit convention, but the PR and release workflows were still partly mixing commit-level wording with PR-level and release-level communication.

That made it easier for agents to create inconsistent PR titles, overly technical PR bodies, or release notes that were too close to raw commit history.

## Impact
Future PRs should be more consistent for reviewers, and future release notes should better match user-facing expectations.

The workflow docs are now better aligned with the repository's squash-merge model and current commit-message convention.

## Validation
- `ruff check .`
- `ruff format --check .`
- `pytest -q`
