### PR TITLE
[codex] Prevent duplicate Renovate vi_api_client PRs

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -5,6 +5,9 @@
   ],
   "dependencyDashboard": true,
   "separateMinorPatch": true,
+  "homeassistant-manifest": {
+    "enabled": false
+  },
   "packageRules": [
     {
       "matchManagers": [


### PR DESCRIPTION
## Summary
- disable Renovate's built-in homeassistant-manifest manager
- keep vi_api_client updates flowing through the existing custom regex manager only
- prevent duplicate dependency PRs for the same vi_api_client update

## Why
The repository currently detects the manifest dependency twice, which can create duplicate Renovate PRs with inconsistent CI coverage.

## Validation
- validated renovate.json with python3 -m json.tool
- checked documentation drift; no updates were needed