### PR TITLE
[codex] Add prerelease publishing workflow

### DIFF
--- a/.agent/rules/git-workflow.md
+++ b/.agent/rules/git-workflow.md
@@ -48,6 +48,11 @@ Strict guidelines for version control and feature development.
 3. **Tag**: `git tag -a vX.Y.Z -m "Release vX.Y.Z"`
 4. **Push Tag**: `git push origin vX.Y.Z`
    - *This triggers the Release Workflow on GitHub.*
+5. **Optional Pre-release Tags**: For Home Assistant validation before a stable
+   release, use semver prerelease tags such as `vX.Y.Z-alpha.N`,
+   `vX.Y.Z-beta.N`, or `vX.Y.Z-rc.N`.
+   - *These trigger the dedicated Pre-release Workflow and create a GitHub
+     prerelease instead of a stable release.*
 
 ## 4. Agent Role & Permissions
 - **Allowed**: `git checkout -b`, `git add`, `git commit`, `git push`.

--- a/.agent/workflows/release.md
+++ b/.agent/workflows/release.md
@@ -6,6 +6,16 @@ description: analyze changes, bump version, generate changelog, and tag release
 
 This workflow guides the agent to create a semantic release for the Home Assistant integration.
 
+## Stable vs. Pre-release Tags
+
+- This workflow describes the stable release path for tags like `vX.Y.Z`.
+- Prerelease validation builds use the dedicated GitHub Actions workflow
+  `.github/workflows/pre-release.yml`.
+- Supported prerelease tag formats are `vX.Y.Z-alpha.N`,
+  `vX.Y.Z-beta.N`, and `vX.Y.Z-rc.N`.
+- Hyphenated prerelease tags are intentionally excluded from the stable release
+  publish step so they create GitHub prereleases instead of full releases.
+
 ## 1. Pre-Flight Checks
 1.  **Branch Check**: Ensure `main` is fully up-to-date.
     ```bash
@@ -119,6 +129,8 @@ Reference PRs or commits when useful, but do not depend on scopes being present.
 - Do not claim the release is live until:
   - the PR merge produced a green `main` push run, and
   - the tag run for `v<NEW_VERSION>` is green.
+- For prerelease validation tags, use the matching `pre-release.yml` run instead
+  of the stable tag run.
 - Perform a final documentation drift check for release-related guidance:
   - `README.md`
   - `AGENTS.md`

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -1,25 +1,24 @@
-name: CI/CD Pipeline
+name: Pre-release Pipeline
 
 env:
   PYTHON_VERSION: "3.14"
 
 on:
   push:
-    branches: [ "main" ]
-    tags: [ "v*" ]
-  pull_request:
-    branches: [ "main" ]
+    tags:
+      - "v*-alpha.*"
+      - "v*-beta.*"
+      - "v*-rc.*"
 
 jobs:
   quality-check:
-    if: github.event_name != 'push' || !startsWith(github.ref, 'refs/tags/v') || !contains(github.ref_name, '-')
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v6
     - uses: actions/setup-python@v6
       with:
         python-version: ${{ env.PYTHON_VERSION }}
-        cache: 'pip'
+        cache: "pip"
     - name: Install
       run: |
         python -m pip install --upgrade pip
@@ -32,9 +31,8 @@ jobs:
     - name: Tests
       run: python -m pytest -q
 
-  release:
+  pre-release:
     needs: quality-check
-    if: startsWith(github.ref, 'refs/tags/v') && !contains(github.ref_name, '-')
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -55,9 +53,10 @@ jobs:
         echo "body<<EOF" >> $GITHUB_OUTPUT
         echo "$TAG_MSG" >> $GITHUB_OUTPUT
         echo "EOF" >> $GITHUB_OUTPUT
-    - name: GitHub Release
+    - name: GitHub Pre-release
       uses: softprops/action-gh-release@v2
       with:
         files: dist/*
         body: ${{ steps.tag_message.outputs.body }}
         generate_release_notes: false
+        prerelease: true

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -114,7 +114,9 @@ validate once in a fresh environment installed with `.[dev]`.
 
 ## CI and Release Notes
 
-- CI currently runs via `.github/workflows/release.yml`.
+- CI currently runs via `.github/workflows/release.yml` for `main`, pull
+  requests, and stable release tags, plus `.github/workflows/pre-release.yml`
+  for prerelease tags.
 - `main` is protected by a GitHub ruleset. Assume pull requests are required for
   all changes, including `.agent/` guidance and documentation updates, unless
   the user explicitly asks for a confirmed emergency bypass.
@@ -125,8 +127,13 @@ validate once in a fresh environment installed with `.[dev]`.
 - Keep `pyproject.toml` package metadata version aligned with
   `custom_components/vi_climate_devices/manifest.json` during releases unless a
   task explicitly requires them to diverge.
+- Stable tags use the format `vX.Y.Z`.
+- Prerelease tags use semver prerelease suffixes such as
+  `vX.Y.Z-alpha.N`, `vX.Y.Z-beta.N`, or `vX.Y.Z-rc.N`.
 - A release is not considered live until both the `main` push run and the tag
   run are green.
+- A prerelease is not considered available for testing until the prerelease tag
+  run is green.
 - Snapshot and Home Assistant test stack changes must be validated against the
   Linux CI run, not only against local macOS runs. A local green snapshot test
   does not guarantee the same result on GitHub Actions.

--- a/README.md
+++ b/README.md
@@ -54,6 +54,11 @@ Tested with:
 2. Copy the `custom_components/vi_climate_devices` folder to your HA `config/custom_components/` directory
 3. Restart Home Assistant
 
+### Testing Pre-releases
+
+If a GitHub prerelease is available, enable beta versions for this repository in
+HACS and install the prerelease there before promoting it to a stable release.
+
 ---
 
 ### Configuration


### PR DESCRIPTION
## Summary
- add a dedicated GitHub Actions workflow for alpha, beta, and rc tags that runs checks and publishes a GitHub prerelease
- prevent the stable release job from publishing hyphenated prerelease tags as full releases
- document prerelease tag formats and the new testing flow in the repo guidance and README

## Verification
- workflow YAML parsed successfully via Ruby YAML
- ruff check .
- ruff format --check .
- /tmp/vi-climate-ci-repro/bin/ruff check .
- /tmp/vi-climate-ci-repro/bin/ruff format --check .
- /tmp/vi-climate-ci-repro/bin/python -m pytest -q

## Pre-release tags
- vX.Y.Z-alpha.N
- vX.Y.Z-beta.N
- vX.Y.Z-rc.N