### PR TITLE
[codex] Prepare 1.1.0-beta.1 prerelease

### DIFF
--- a/custom_components/vi_climate_devices/manifest.json
+++ b/custom_components/vi_climate_devices/manifest.json
@@ -15,5 +15,5 @@
   "requirements": [
     "vi_api_client @ git+https://github.com/ignazhabibi/vi_api_client.git@v1.2.0"
   ],
-  "version": "1.0.6"
+  "version": "1.1.0-beta.1"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vi_climate_devices"
-version = "1.0.6"
+version = "1.1.0-beta.1"
 description = "Viessmann Climate Devices Integration for Home Assistant"
 authors = [
   { name = "Michael", email = "notme@bieber-home.net" },


### PR DESCRIPTION
## Summary
- bump manifest.json and pyproject.toml from 1.0.6 to 1.1.0-beta.1
- align the repo version with the first prerelease target after v1.0.6
- keep HACS, Home Assistant, and GitHub tag versioning consistent for the beta release

## Why 1.1.0-beta.1
- the current stable release is v1.0.6
- there is feature work on main since that tag, so the next semver target is 1.1.0
- prereleases for an already-published stable version like 1.0.6-beta.1 would be misleading

## Verification
- ruff check .
- ruff format --check .
- /tmp/vi-climate-ci-repro/bin/python -m pytest -q

## Next Step After Merge
- create and push the annotated tag v1.1.0-beta.1 on the merged main commit to trigger the prerelease workflow