### PR TITLE
[codex] Rename energy sensors

### DIFF
--- a/custom_components/vi_climate_devices/strings.json
+++ b/custom_components/vi_climate_devices/strings.json
@@ -202,22 +202,22 @@
                 "name": "Volumetric Flow"
             },
             "consumption_total": {
-                "name": "Power Consumption Total (Today)"
+                "name": "Total Consumption Today"
             },
             "consumption_heating": {
-                "name": "Power Consumption Heating (Today)"
+                "name": "Heating Consumption Today"
             },
             "consumption_dhw": {
-                "name": "Power Consumption DHW (Today)"
+                "name": "DHW Consumption Today"
             },
             "consumption_dhw_current_year": {
-                "name": "Consumption Dhw Current Year"
+                "name": "DHW Consumption Year"
             },
             "consumption_heating_current_year": {
-                "name": "Consumption Heating Current Year"
+                "name": "Heating Consumption Year"
             },
             "consumption_total_current_year": {
-                "name": "Consumption Total Current Year"
+                "name": "Total Consumption Year"
             },
             "burner_starts": {
                 "name": "Burner {index} Starts"
@@ -226,25 +226,25 @@
                 "name": "Burner {index} Hours"
             },
             "production_dhw_current_day": {
-                "name": "Produced Energy DHW (Today)"
+                "name": "DHW Production Today"
             },
             "production_heating_current_day": {
-                "name": "Produced Energy Heating (Today)"
+                "name": "Heating Production Today"
             },
             "production_cooling_current_year": {
-                "name": "Production Cooling Current Year"
+                "name": "Cooling Production Year"
             },
             "production_dhw_current_year": {
-                "name": "Production Dhw Current Year"
+                "name": "DHW Production Year"
             },
             "production_heating_current_year": {
-                "name": "Production Heating Current Year"
+                "name": "Heating Production Year"
             },
             "heating_rod_consumption_dhw_current_year": {
-                "name": "Heating Rod Consumption Dhw Current Year"
+                "name": "Heating Rod DHW Consumption Year"
             },
             "heating_rod_consumption_heating_current_year": {
-                "name": "Heating Rod Consumption Heating Current Year"
+                "name": "Heating Rod Heating Consumption Year"
             },
             "inverter_power_output": {
                 "name": "Inverter {index} Power Output"
@@ -292,7 +292,7 @@
                 "name": "Solar Hot Water Temperature"
             },
             "solar_production_today": {
-                "name": "Solar Power Production (Day)"
+                "name": "Solar Production Today"
             },
             "compressor_phase": {
                 "name": "Compressor {index} Phase"

--- a/custom_components/vi_climate_devices/translations/de.json
+++ b/custom_components/vi_climate_devices/translations/de.json
@@ -177,22 +177,22 @@
                 "name": "Volumenstrom"
             },
             "consumption_total": {
-                "name": "Verbrauch Gesamt (Heute)"
+                "name": "Verbrauch Gesamt Heute"
             },
             "consumption_heating": {
-                "name": "Verbrauch Heizung (Heute)"
+                "name": "Verbrauch Heizung Heute"
             },
             "consumption_dhw": {
-                "name": "Verbrauch Warmwasser (Heute)"
+                "name": "Verbrauch Warmwasser Heute"
             },
             "consumption_dhw_current_year": {
-                "name": "Verbrauch Warmwasser Aktuelles Jahr"
+                "name": "Verbrauch Warmwasser Jahr"
             },
             "consumption_heating_current_year": {
-                "name": "Verbrauch Heizung Aktuelles Jahr"
+                "name": "Verbrauch Heizung Jahr"
             },
             "consumption_total_current_year": {
-                "name": "Verbrauch Gesamt Aktuelles Jahr"
+                "name": "Verbrauch Gesamt Jahr"
             },
             "burner_starts": {
                 "name": "Brennerstarts {index}"
@@ -201,25 +201,25 @@
                 "name": "Brennerbetriebsstunden {index}"
             },
             "production_dhw_current_day": {
-                "name": "Erzeugte Energie Warmwasser (Heute)"
+                "name": "Erzeugung Warmwasser Heute"
             },
             "production_heating_current_day": {
-                "name": "Erzeugte Energie Heizung (Heute)"
+                "name": "Erzeugung Heizung Heute"
             },
             "production_cooling_current_year": {
-                "name": "Erzeugung Kuehlung Aktuelles Jahr"
+                "name": "Erzeugung Kuehlung Jahr"
             },
             "production_dhw_current_year": {
-                "name": "Erzeugung Warmwasser Aktuelles Jahr"
+                "name": "Erzeugung Warmwasser Jahr"
             },
             "production_heating_current_year": {
-                "name": "Erzeugung Heizung Aktuelles Jahr"
+                "name": "Erzeugung Heizung Jahr"
             },
             "heating_rod_consumption_dhw_current_year": {
-                "name": "Heizstab Verbrauch Warmwasser Aktuelles Jahr"
+                "name": "Verbrauch Heizstab Warmwasser Jahr"
             },
             "heating_rod_consumption_heating_current_year": {
-                "name": "Heizstab Verbrauch Heizung Aktuelles Jahr"
+                "name": "Verbrauch Heizstab Heizung Jahr"
             },
             "inverter_power_output": {
                 "name": "Aktueller Stromverbrauch {index}"
@@ -267,7 +267,7 @@
                 "name": "Solar Warmwassertemperatur"
             },
             "solar_production_today": {
-                "name": "Solarertrag (Tag)"
+                "name": "Solarertrag Heute"
             },
             "compressor_phase": {
                 "name": "Verdichter {index} Phase"

--- a/custom_components/vi_climate_devices/translations/en.json
+++ b/custom_components/vi_climate_devices/translations/en.json
@@ -177,22 +177,22 @@
                 "name": "Volumetric Flow"
             },
             "consumption_total": {
-                "name": "Power Consumption Total (Today)"
+                "name": "Total Consumption Today"
             },
             "consumption_heating": {
-                "name": "Power Consumption Heating (Today)"
+                "name": "Heating Consumption Today"
             },
             "consumption_dhw": {
-                "name": "Power Consumption DHW (Today)"
+                "name": "DHW Consumption Today"
             },
             "consumption_dhw_current_year": {
-                "name": "Consumption Dhw Current Year"
+                "name": "DHW Consumption Year"
             },
             "consumption_heating_current_year": {
-                "name": "Consumption Heating Current Year"
+                "name": "Heating Consumption Year"
             },
             "consumption_total_current_year": {
-                "name": "Consumption Total Current Year"
+                "name": "Total Consumption Year"
             },
             "burner_starts": {
                 "name": "Burner {index} Starts"
@@ -201,25 +201,25 @@
                 "name": "Burner {index} Hours"
             },
             "production_dhw_current_day": {
-                "name": "Produced Energy DHW (Today)"
+                "name": "DHW Production Today"
             },
             "production_heating_current_day": {
-                "name": "Produced Energy Heating (Today)"
+                "name": "Heating Production Today"
             },
             "production_cooling_current_year": {
-                "name": "Production Cooling Current Year"
+                "name": "Cooling Production Year"
             },
             "production_dhw_current_year": {
-                "name": "Production Dhw Current Year"
+                "name": "DHW Production Year"
             },
             "production_heating_current_year": {
-                "name": "Production Heating Current Year"
+                "name": "Heating Production Year"
             },
             "heating_rod_consumption_dhw_current_year": {
-                "name": "Heating Rod Consumption Dhw Current Year"
+                "name": "Heating Rod DHW Consumption Year"
             },
             "heating_rod_consumption_heating_current_year": {
-                "name": "Heating Rod Consumption Heating Current Year"
+                "name": "Heating Rod Heating Consumption Year"
             },
             "inverter_power_output": {
                 "name": "Inverter {index} Power Output"
@@ -267,7 +267,7 @@
                 "name": "Solar Hot Water Temperature"
             },
             "solar_production_today": {
-                "name": "Solar Power Production (Day)"
+                "name": "Solar Production Today"
             },
             "compressor_phase": {
                 "name": "Compressor {index} Phase"

--- a/tests/__snapshots__/test_discovery_snapshot.ambr
+++ b/tests/__snapshots__/test_discovery_snapshot.ambr
@@ -853,35 +853,56 @@
     dict({
       'attributes': dict({
         'device_class': 'energy',
-        'friendly_name': 'Vitocal250A Consumption Dhw Current Year',
+        'friendly_name': 'Vitocal250A Cooling Production Year',
+        'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
+        'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
+        'viessmann_feature_name': 'heating.heat.production.summary.cooling.currentYear',
+      }),
+      'entity_id': 'sensor.vitocal250a_cooling_production_year',
+      'state': '0',
+    }),
+    dict({
+      'attributes': dict({
+        'device_class': 'energy',
+        'friendly_name': 'Vitocal250A DHW Consumption Today',
+        'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
+        'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
+      }),
+      'entity_id': 'sensor.vitocal250a_dhw_consumption_today',
+      'state': '10.2',
+    }),
+    dict({
+      'attributes': dict({
+        'device_class': 'energy',
+        'friendly_name': 'Vitocal250A DHW Consumption Year',
         'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
         'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
         'viessmann_feature_name': 'heating.power.consumption.dhw.currentYear',
       }),
-      'entity_id': 'sensor.vitocal250a_consumption_dhw_current_year',
+      'entity_id': 'sensor.vitocal250a_dhw_consumption_year',
       'state': '875.1',
     }),
     dict({
       'attributes': dict({
         'device_class': 'energy',
-        'friendly_name': 'Vitocal250A Consumption Heating Current Year',
+        'friendly_name': 'Vitocal250A DHW Production Today',
         'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
         'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
-        'viessmann_feature_name': 'heating.power.consumption.heating.currentYear',
+        'viessmann_feature_name': 'heating.heat.production.summary.dhw.currentDay',
       }),
-      'entity_id': 'sensor.vitocal250a_consumption_heating_current_year',
-      'state': '2565.7',
+      'entity_id': 'sensor.vitocal250a_dhw_production_today',
+      'state': '9.6',
     }),
     dict({
       'attributes': dict({
         'device_class': 'energy',
-        'friendly_name': 'Vitocal250A Consumption Total Current Year',
+        'friendly_name': 'Vitocal250A DHW Production Year',
         'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
         'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
-        'viessmann_feature_name': 'heating.power.consumption.total.currentYear',
+        'viessmann_feature_name': 'heating.heat.production.summary.dhw.currentYear',
       }),
-      'entity_id': 'sensor.vitocal250a_consumption_total_current_year',
-      'state': '3440.8',
+      'entity_id': 'sensor.vitocal250a_dhw_production_year',
+      'state': '3382.9',
     }),
     dict({
       'attributes': dict({
@@ -997,23 +1018,66 @@
     dict({
       'attributes': dict({
         'device_class': 'energy',
-        'friendly_name': 'Vitocal250A Heating Rod Consumption Dhw Current Year',
+        'friendly_name': 'Vitocal250A Heating Consumption Today',
+        'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
+        'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
+      }),
+      'entity_id': 'sensor.vitocal250a_heating_consumption_today',
+      'state': '31.6',
+    }),
+    dict({
+      'attributes': dict({
+        'device_class': 'energy',
+        'friendly_name': 'Vitocal250A Heating Consumption Year',
+        'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
+        'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
+        'viessmann_feature_name': 'heating.power.consumption.heating.currentYear',
+      }),
+      'entity_id': 'sensor.vitocal250a_heating_consumption_year',
+      'state': '2565.7',
+    }),
+    dict({
+      'attributes': dict({
+        'device_class': 'energy',
+        'friendly_name': 'Vitocal250A Heating Production Today',
+        'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
+        'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
+        'viessmann_feature_name': 'heating.heat.production.summary.heating.currentDay',
+      }),
+      'entity_id': 'sensor.vitocal250a_heating_production_today',
+      'state': '22.8',
+    }),
+    dict({
+      'attributes': dict({
+        'device_class': 'energy',
+        'friendly_name': 'Vitocal250A Heating Production Year',
+        'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
+        'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
+        'viessmann_feature_name': 'heating.heat.production.summary.heating.currentYear',
+      }),
+      'entity_id': 'sensor.vitocal250a_heating_production_year',
+      'state': '10024.2',
+    }),
+    dict({
+      'attributes': dict({
+        'device_class': 'energy',
+        'friendly_name': 'Vitocal250A Heating Rod DHW Consumption Year',
         'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
         'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
         'viessmann_feature_name': 'heating.heatingRod.power.consumption.summary.dhw.currentYear',
       }),
-      'entity_id': 'sensor.vitocal250a_heating_rod_consumption_dhw_current_year',
+      'entity_id': 'sensor.vitocal250a_heating_rod_dhw_consumption_year',
       'state': '3.3',
     }),
     dict({
       'attributes': dict({
         'device_class': 'energy',
-        'friendly_name': 'Vitocal250A Heating Rod Consumption Heating Current Year',
+        'friendly_name': 'Vitocal250A Heating Rod Heating Consumption Year',
         'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
         'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
         'viessmann_feature_name': 'heating.heatingRod.power.consumption.summary.heating.currentYear',
       }),
-      'entity_id': 'sensor.vitocal250a_heating_rod_consumption_heating_current_year',
+      'entity_id': 'sensor.vitocal250a_heating_rod_heating_consumption_year',
       'state': '29.5',
     }),
     dict({
@@ -1194,36 +1258,6 @@
     }),
     dict({
       'attributes': dict({
-        'device_class': 'energy',
-        'friendly_name': 'Vitocal250A Power Consumption DHW (Today)',
-        'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
-        'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
-      }),
-      'entity_id': 'sensor.vitocal250a_power_consumption_dhw_today',
-      'state': '10.2',
-    }),
-    dict({
-      'attributes': dict({
-        'device_class': 'energy',
-        'friendly_name': 'Vitocal250A Power Consumption Heating (Today)',
-        'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
-        'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
-      }),
-      'entity_id': 'sensor.vitocal250a_power_consumption_heating_today',
-      'state': '31.6',
-    }),
-    dict({
-      'attributes': dict({
-        'device_class': 'energy',
-        'friendly_name': 'Vitocal250A Power Consumption Total (Today)',
-        'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
-        'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
-      }),
-      'entity_id': 'sensor.vitocal250a_power_consumption_total_today',
-      'state': '41.8',
-    }),
-    dict({
-      'attributes': dict({
         'device_class': 'temperature',
         'friendly_name': 'Vitocal250A Primary Circuit Supply Temperature',
         'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
@@ -1232,61 +1266,6 @@
       }),
       'entity_id': 'sensor.vitocal250a_primary_circuit_supply_temperature',
       'state': '13.9',
-    }),
-    dict({
-      'attributes': dict({
-        'device_class': 'energy',
-        'friendly_name': 'Vitocal250A Produced Energy DHW (Today)',
-        'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
-        'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
-        'viessmann_feature_name': 'heating.heat.production.summary.dhw.currentDay',
-      }),
-      'entity_id': 'sensor.vitocal250a_produced_energy_dhw_today',
-      'state': '9.6',
-    }),
-    dict({
-      'attributes': dict({
-        'device_class': 'energy',
-        'friendly_name': 'Vitocal250A Produced Energy Heating (Today)',
-        'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
-        'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
-        'viessmann_feature_name': 'heating.heat.production.summary.heating.currentDay',
-      }),
-      'entity_id': 'sensor.vitocal250a_produced_energy_heating_today',
-      'state': '22.8',
-    }),
-    dict({
-      'attributes': dict({
-        'device_class': 'energy',
-        'friendly_name': 'Vitocal250A Production Cooling Current Year',
-        'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
-        'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
-        'viessmann_feature_name': 'heating.heat.production.summary.cooling.currentYear',
-      }),
-      'entity_id': 'sensor.vitocal250a_production_cooling_current_year',
-      'state': '0',
-    }),
-    dict({
-      'attributes': dict({
-        'device_class': 'energy',
-        'friendly_name': 'Vitocal250A Production Dhw Current Year',
-        'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
-        'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
-        'viessmann_feature_name': 'heating.heat.production.summary.dhw.currentYear',
-      }),
-      'entity_id': 'sensor.vitocal250a_production_dhw_current_year',
-      'state': '3382.9',
-    }),
-    dict({
-      'attributes': dict({
-        'device_class': 'energy',
-        'friendly_name': 'Vitocal250A Production Heating Current Year',
-        'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
-        'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
-        'viessmann_feature_name': 'heating.heat.production.summary.heating.currentYear',
-      }),
-      'entity_id': 'sensor.vitocal250a_production_heating_current_year',
-      'state': '10024.2',
     }),
     dict({
       'attributes': dict({
@@ -1454,6 +1433,27 @@
       }),
       'entity_id': 'sensor.vitocal250a_temperature_outside_damping_factor',
       'state': '10',
+    }),
+    dict({
+      'attributes': dict({
+        'device_class': 'energy',
+        'friendly_name': 'Vitocal250A Total Consumption Today',
+        'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
+        'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
+      }),
+      'entity_id': 'sensor.vitocal250a_total_consumption_today',
+      'state': '41.8',
+    }),
+    dict({
+      'attributes': dict({
+        'device_class': 'energy',
+        'friendly_name': 'Vitocal250A Total Consumption Year',
+        'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
+        'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
+        'viessmann_feature_name': 'heating.power.consumption.total.currentYear',
+      }),
+      'entity_id': 'sensor.vitocal250a_total_consumption_year',
+      'state': '3440.8',
     }),
     dict({
       'attributes': dict({

--- a/tests/test_analytics.py
+++ b/tests/test_analytics.py
@@ -42,8 +42,8 @@ async def test_analytics_sensors_setup_and_data(hass: HomeAssistant, mock_client
         await hass.async_block_till_done()
 
         # Assert: Verify total consumption sensor.
-        # Entity ID derived from translation key "consumption_total" -> "Power Consumption Total Today"
-        state = hass.states.get("sensor.vitocal250a_power_consumption_total_today")
+        # Entity ID derived from translation key "consumption_total" -> "Total Consumption Today"
+        state = hass.states.get("sensor.vitocal250a_total_consumption_today")
         assert state is not None
         assert state.state == "41.8"
         assert state.attributes["unit_of_measurement"] == "kWh"
@@ -51,12 +51,12 @@ async def test_analytics_sensors_setup_and_data(hass: HomeAssistant, mock_client
         assert state.attributes["state_class"] == "total_increasing"
 
         # Assert: Verify heating consumption sensor.
-        state = hass.states.get("sensor.vitocal250a_power_consumption_heating_today")
+        state = hass.states.get("sensor.vitocal250a_heating_consumption_today")
         assert state is not None
         assert state.state == "31.6"
 
         # Assert: Verify DHW consumption sensor.
-        state = hass.states.get("sensor.vitocal250a_power_consumption_dhw_today")
+        state = hass.states.get("sensor.vitocal250a_dhw_consumption_today")
         assert state is not None
         assert state.state == "10.2"
 


### PR DESCRIPTION
## Summary
- rename consumption and production sensor labels to use the new Heute and Jahr wording
- remove Aktuelles and Current from year-based energy sensor names
- update analytics expectations and discovery snapshot for the resulting entity ids on fresh installs

## Naming examples
- Verbrauch Heizung Jahr
- Verbrauch Warmwasser Jahr
- Verbrauch Gesamt Jahr
- Verbrauch Heizstab Heizung Jahr
- Erzeugung Heizung Heute

## Verification
- ruff check .
- ruff format --check .
- /tmp/vi-climate-ci-repro/bin/python -m pytest -q