### PR TITLE
[codex] Prepare 1.1.0-beta.2 prerelease

### DIFF
--- a/custom_components/vi_climate_devices/manifest.json
+++ b/custom_components/vi_climate_devices/manifest.json
@@ -15,5 +15,5 @@
   "requirements": [
     "vi_api_client @ git+https://github.com/ignazhabibi/vi_api_client.git@v1.2.0"
   ],
-  "version": "1.1.0-beta.1"
+  "version": "1.1.0-beta.2"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vi_climate_devices"
-version = "1.1.0-beta.1"
+version = "1.1.0-beta.2"
 description = "Viessmann Climate Devices Integration for Home Assistant"
 authors = [
   { name = "Michael", email = "notme@bieber-home.net" },


### PR DESCRIPTION
## Summary
- bump manifest.json and pyproject.toml from 1.1.0-beta.1 to 1.1.0-beta.2
- package the merged energy sensor renaming work into the next prerelease candidate
- keep Home Assistant, HACS, and GitHub tag versioning aligned for beta 2

## Why beta 2
- beta 1 is already published as v1.1.0-beta.1
- main now includes the merged energy sensor rename changes
- beta 2 is the next prerelease candidate for validating that update in Home Assistant

## Verification
- ruff check .
- ruff format --check .
- /tmp/vi-climate-ci-repro/bin/python -m pytest -q

## Next Step After Merge
- create and push the annotated tag v1.1.0-beta.2 on the merged main commit to trigger the prerelease workflow