### PR TITLE
[codex] Set 3-minute polling interval

### DIFF
--- a/custom_components/vi_climate_devices/coordinator.py
+++ b/custom_components/vi_climate_devices/coordinator.py
@@ -34,7 +34,7 @@ class ViClimateDataUpdateCoordinator(DataUpdateCoordinator):
             hass,
             _LOGGER,
             name=f"{DOMAIN}_data",
-            update_interval=update_interval or timedelta(minutes=5),
+            update_interval=update_interval or timedelta(minutes=3),
         )
         self.client = client
         self._known_devices: list[Device] = []


### PR DESCRIPTION
## What changed
- reduced the default Viessmann data coordinator polling interval from 5 minutes to 3 minutes

## Why
- removing the separate analytics coordinator freed up API budget
- a 3-minute interval gives faster state updates while staying comfortably within the Viessmann daily rate limit for a typical single-device setup

## Validation
- `ruff check custom_components/vi_climate_devices/coordinator.py`
- `.venv/bin/python -m pytest tests/test_coordinator.py -q`
- `.venv/bin/python -m pytest -q`

## Notes
- documentation drift was checked and no repository docs needed updates because the old 5-minute interval was not documented
