### PR TITLE
[codex] Bump version to 1.1.0-beta.3

### DIFF
--- a/custom_components/vi_climate_devices/manifest.json
+++ b/custom_components/vi_climate_devices/manifest.json
@@ -15,5 +15,5 @@
   "requirements": [
     "vi_api_client @ git+https://github.com/ignazhabibi/vi_api_client.git@v1.2.0"
   ],
-  "version": "1.1.0-beta.2"
+  "version": "1.1.0-beta.3"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vi_climate_devices"
-version = "1.1.0-beta.2"
+version = "1.1.0-beta.3"
 description = "Viessmann Climate Devices Integration for Home Assistant"
 authors = [
   { name = "Michael", email = "notme@bieber-home.net" },


### PR DESCRIPTION
## Summary
- bump the integration version from 1.1.0-beta.2 to 1.1.0-beta.3 in manifest.json and pyproject.toml
- prepare the next Home Assistant prerelease build after the merged polling interval change

## Validation
- ruff check .
- ruff format --check .
- .venv/bin/python -m pytest -q
- /tmp/vi-climate-remove-today/bin/python -m pytest -q