### PR TITLE
Add HVAC actions for climate circuits

### DIFF
--- a/custom_components/vi_climate_devices/climate.py
+++ b/custom_components/vi_climate_devices/climate.py
@@ -8,6 +8,7 @@ from typing import Any
 from homeassistant.components.climate import (
     ClimateEntity,
     ClimateEntityFeature,
+    HVACAction,
     HVACMode,
 )
 from homeassistant.components.climate.const import (
@@ -31,6 +32,13 @@ from .coordinator import ViClimateDataUpdateCoordinator
 from .utils import get_suggested_precision
 
 _LOGGER = logging.getLogger(__name__)
+
+# Mapping from Viessmann demand directions to Home Assistant HVACAction.
+# Sort the keys alphabetically.
+API_TO_HA_HVAC_ACTION = {
+    "cooling": HVACAction.COOLING,
+    "heating": HVACAction.HEATING,
+}
 
 # Mapping from Viessmann API operation modes to Home Assistant HVACMode.
 # Sort the keys alphabetically.
@@ -156,6 +164,120 @@ class ViClimate(CoordinatorEntity, ClimateEntity):
         if not device:
             return None
         return device.get_feature(name)
+
+    def _get_circuit_pump_state(self, circuit_index: str | None = None) -> bool | None:
+        """Return whether a heating circuit pump is running."""
+        target_circuit_index = circuit_index or self._circuit_index
+        pump_feature = self._get_feature(
+            f"heating.circuits.{target_circuit_index}.circulation.pump.status"
+        )
+        if not pump_feature:
+            return None
+
+        if isinstance(pump_feature.value, bool):
+            return pump_feature.value
+        if isinstance(pump_feature.value, str):
+            pump_status = pump_feature.value.lower()
+            if pump_status == "off":
+                return False
+            if pump_status == "on":
+                return True
+        return None
+
+    def _get_generator_active_state(self) -> bool | None:
+        """Return whether a compressor or burner is currently active."""
+        device = self.coordinator.data.get(self._map_key)
+        if not device:
+            return None
+
+        generator_states: list[bool] = []
+        has_unknown_state = False
+        for feature in device.features:
+            feature_parts = feature.name.split(".")
+            if (
+                len(feature_parts) != 4
+                or feature_parts[0] != "heating"
+                or feature_parts[1] not in {"burners", "compressors"}
+                or feature_parts[3] != "active"
+            ):
+                continue
+
+            if isinstance(feature.value, bool):
+                generator_states.append(feature.value)
+            else:
+                has_unknown_state = True
+
+        if any(generator_states):
+            return True
+        if generator_states and not has_unknown_state:
+            return False
+        return None
+
+    def _has_conflicting_circuit_demand(self, action: HVACAction) -> bool:
+        """Return whether another running circuit has an opposite demand."""
+        device = self.coordinator.data.get(self._map_key)
+        if not device:
+            return False
+
+        for feature in device.features:
+            feature_parts = feature.name.split(".")
+            if (
+                len(feature_parts) != 6
+                or feature_parts[0] != "heating"
+                or feature_parts[1] != "circuits"
+                or feature_parts[2] == self._circuit_index
+                or feature_parts[3:] != ["operating", "programs", "active"]
+                or not feature.value
+            ):
+                continue
+
+            circuit_index = feature_parts[2]
+            if self._get_circuit_pump_state(circuit_index) is not True:
+                continue
+
+            demand_feature = self._get_feature(
+                f"heating.circuits.{circuit_index}.operating.programs."
+                f"{feature.value}.demand"
+            )
+            if not demand_feature:
+                continue
+
+            circuit_action = API_TO_HA_HVAC_ACTION.get(str(demand_feature.value))
+            if circuit_action is not None and circuit_action != action:
+                return True
+
+        return False
+
+    def _determine_current_action(self) -> HVACAction | None:
+        """Determine the current heating or cooling direction."""
+        action: HVACAction | None = None
+        active_program_feature = self._get_feature(
+            f"heating.circuits.{self._circuit_index}.operating.programs.active"
+        )
+        if active_program_feature and active_program_feature.value:
+            active_program = str(active_program_feature.value)
+            demand_feature = self._get_feature(
+                f"heating.circuits.{self._circuit_index}.operating.programs."
+                f"{active_program}.demand"
+            )
+            if demand_feature:
+                action = API_TO_HA_HVAC_ACTION.get(str(demand_feature.value))
+                if (
+                    action == HVACAction.COOLING and self.hvac_mode == HVACMode.HEAT
+                ) or (action == HVACAction.HEATING and self.hvac_mode == HVACMode.COOL):
+                    action = None
+            elif self.hvac_mode == HVACMode.COOL:
+                action = HVACAction.COOLING
+            elif self.hvac_mode == HVACMode.HEAT:
+                action = HVACAction.HEATING
+        elif self.hvac_mode == HVACMode.COOL:
+            action = HVACAction.COOLING
+        elif self.hvac_mode == HVACMode.HEAT:
+            action = HVACAction.HEATING
+
+        if action is not None and self._has_conflicting_circuit_demand(action):
+            action = None
+        return action
 
     def _get_program_base_name(self, program_name: str) -> str:
         """Get the base prefix of a program name (e.g., 'normalHeating' -> 'normal')."""
@@ -288,6 +410,33 @@ class ViClimate(CoordinatorEntity, ClimateEntity):
         if mode_feature and mode_feature.value:
             return API_TO_HA_HVAC_MODE.get(str(mode_feature.value))
         return None
+
+    @property
+    def hvac_action(self) -> HVACAction | None:
+        """Return the current HVAC action."""
+        action: HVACAction | None = None
+        defrosting_feature = self._get_feature("heating.outdoor.defrosting.active")
+        if defrosting_feature and defrosting_feature.value is True:
+            action = HVACAction.DEFROSTING
+        elif self.hvac_mode == HVACMode.OFF:
+            action = HVACAction.OFF
+        else:
+            valve_position_feature = self._get_feature(
+                "heating.valves.fourThreeWay.position"
+            )
+            if (
+                valve_position_feature
+                and valve_position_feature.value == "domesticHotWater"
+            ):
+                action = HVACAction.IDLE
+            else:
+                pump_state = self._get_circuit_pump_state()
+                if pump_state is False:
+                    action = HVACAction.IDLE
+                elif pump_state is True and self._get_generator_active_state() is True:
+                    action = self._determine_current_action()
+
+        return action
 
     @property
     def hvac_modes(self) -> list[HVACMode]:

--- a/tests/test_climate.py
+++ b/tests/test_climate.py
@@ -7,6 +7,7 @@ from homeassistant.components.climate import (
     SERVICE_SET_HVAC_MODE,
     SERVICE_SET_PRESET_MODE,
     SERVICE_SET_TEMPERATURE,
+    HVACAction,
     HVACMode,
 )
 from homeassistant.components.climate.const import (
@@ -18,9 +19,228 @@ from homeassistant.components.climate.const import (
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from pytest_homeassistant_custom_component.common import MockConfigEntry
+from vi_api_client.mock_client import MockViClient
 from vi_api_client.models import CommandResponse, Device, Feature, FeatureControl
 
+from custom_components.vi_climate_devices.climate import ViClimate
 from custom_components.vi_climate_devices.const import DOMAIN
+
+ACTIVE_PROGRAM_FEATURE = "heating.circuits.0.operating.programs.active"
+BURNER_ACTIVE_FEATURE = "heating.burners.0.active"
+CIRCUIT_MODE_FEATURE = "heating.circuits.0.operating.modes.active"
+CIRCUIT_PUMP_FEATURE = "heating.circuits.0.circulation.pump.status"
+COMPRESSOR_ACTIVE_FEATURE = "heating.compressors.0.active"
+COOLING_DEMAND_FEATURE = (
+    "heating.circuits.0.operating.programs.normalCoolingEnergySaving.demand"
+)
+DEFROSTING_FEATURE = "heating.outdoor.defrosting.active"
+HEATING_DEMAND_FEATURE = "heating.circuits.0.operating.programs.normalHeating.demand"
+HEATING_ROD_ACTIVE_FEATURE = "heating.heatingRod.active"
+VALVE_POSITION_FEATURE = "heating.valves.fourThreeWay.position"
+
+
+async def _create_hvac_action_entity(
+    mock_client: MockViClient,
+    feature_values: dict[str, object],
+    removed_feature_names: frozenset[str],
+) -> ViClimate:
+    """Create a climate entity from an adjusted Vitocal250A fixture."""
+    fixture_devices = await mock_client.get_full_installation_status("99999")
+    fixture_device = fixture_devices[0]
+    fixture_feature_names = {feature.name for feature in fixture_device.features}
+
+    updated_features = [
+        Feature(
+            name=feature.name,
+            value=feature_values.get(feature.name, feature.value),
+            unit=feature.unit,
+            is_enabled=feature.is_enabled,
+            is_ready=feature.is_ready,
+            control=feature.control,
+        )
+        for feature in fixture_device.features
+        if feature.name not in removed_feature_names
+    ]
+    updated_features.extend(
+        Feature(
+            name=feature_name,
+            value=feature_value,
+            unit=None,
+            is_enabled=True,
+            is_ready=True,
+        )
+        for feature_name, feature_value in feature_values.items()
+        if feature_name not in fixture_feature_names
+    )
+
+    device = Device(
+        id=fixture_device.id,
+        gateway_serial=fixture_device.gateway_serial,
+        installation_id=fixture_device.installation_id,
+        model_id=fixture_device.model_id,
+        device_type=fixture_device.device_type,
+        status=fixture_device.status,
+        features=updated_features,
+    )
+    map_key = f"{device.gateway_serial}_{device.id}"
+    coordinator = MagicMock()
+    coordinator.data = {map_key: device}
+    return ViClimate(coordinator, map_key, "0")
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("feature_values", "removed_feature_names", "expected_action"),
+    [
+        pytest.param(
+            {CIRCUIT_MODE_FEATURE: "standby"},
+            frozenset(),
+            HVACAction.OFF,
+            id="standby-is-off",
+        ),
+        pytest.param(
+            {CIRCUIT_MODE_FEATURE: "standby", DEFROSTING_FEATURE: True},
+            frozenset(),
+            HVACAction.DEFROSTING,
+            id="defrosting-takes-priority",
+        ),
+        pytest.param(
+            {
+                COMPRESSOR_ACTIVE_FEATURE: True,
+                DEFROSTING_FEATURE: False,
+                VALVE_POSITION_FEATURE: "climatCircuitTwoDefrost",
+            },
+            frozenset(),
+            HVACAction.HEATING,
+            id="defrost-valve-position-is-not-defrosting",
+        ),
+        pytest.param(
+            {VALVE_POSITION_FEATURE: "domesticHotWater"},
+            frozenset(),
+            HVACAction.IDLE,
+            id="domestic-hot-water-valve-idles-circuit",
+        ),
+        pytest.param(
+            {CIRCUIT_PUMP_FEATURE: "off"},
+            frozenset(),
+            HVACAction.IDLE,
+            id="stopped-circuit-pump-is-idle",
+        ),
+        pytest.param(
+            {
+                CIRCUIT_PUMP_FEATURE: "on",
+                COMPRESSOR_ACTIVE_FEATURE: True,
+                HEATING_DEMAND_FEATURE: "heating",
+            },
+            frozenset(),
+            HVACAction.HEATING,
+            id="active-compressor-with-heating-demand",
+        ),
+        pytest.param(
+            {
+                ACTIVE_PROGRAM_FEATURE: "normalCoolingEnergySaving",
+                CIRCUIT_MODE_FEATURE: "cooling",
+                CIRCUIT_PUMP_FEATURE: "on",
+                COMPRESSOR_ACTIVE_FEATURE: True,
+                COOLING_DEMAND_FEATURE: "cooling",
+            },
+            frozenset(),
+            HVACAction.COOLING,
+            id="active-compressor-with-cooling-demand",
+        ),
+        pytest.param(
+            {
+                CIRCUIT_PUMP_FEATURE: "on",
+                COMPRESSOR_ACTIVE_FEATURE: False,
+            },
+            frozenset(),
+            None,
+            id="inactive-compressor-is-unknown",
+        ),
+        pytest.param(
+            {
+                CIRCUIT_MODE_FEATURE: "dhwAndHeatingCooling",
+                CIRCUIT_PUMP_FEATURE: "on",
+                COMPRESSOR_ACTIVE_FEATURE: True,
+            },
+            frozenset({HEATING_DEMAND_FEATURE}),
+            None,
+            id="combined-mode-without-demand-is-unknown",
+        ),
+        pytest.param(
+            {
+                CIRCUIT_PUMP_FEATURE: "on",
+                COMPRESSOR_ACTIVE_FEATURE: False,
+                HEATING_ROD_ACTIVE_FEATURE: True,
+            },
+            frozenset(),
+            None,
+            id="heating-rod-does-not-drive-action",
+        ),
+        pytest.param(
+            {
+                BURNER_ACTIVE_FEATURE: True,
+                CIRCUIT_PUMP_FEATURE: "on",
+                COMPRESSOR_ACTIVE_FEATURE: False,
+                HEATING_DEMAND_FEATURE: "heating",
+            },
+            frozenset(),
+            HVACAction.HEATING,
+            id="active-burner-drives-action",
+        ),
+        pytest.param(
+            {
+                CIRCUIT_MODE_FEATURE: "heating",
+                CIRCUIT_PUMP_FEATURE: "on",
+                COMPRESSOR_ACTIVE_FEATURE: True,
+            },
+            frozenset({HEATING_DEMAND_FEATURE}),
+            HVACAction.HEATING,
+            id="heating-mode-is-demand-fallback",
+        ),
+        pytest.param(
+            {
+                ACTIVE_PROGRAM_FEATURE: "normalCoolingEnergySaving",
+                CIRCUIT_MODE_FEATURE: "cooling",
+                CIRCUIT_PUMP_FEATURE: "on",
+                COMPRESSOR_ACTIVE_FEATURE: True,
+            },
+            frozenset({COOLING_DEMAND_FEATURE}),
+            HVACAction.COOLING,
+            id="cooling-mode-is-demand-fallback",
+        ),
+        pytest.param(
+            {
+                "heating.circuits.1.circulation.pump.status": "on",
+                "heating.circuits.1.operating.programs.active": "normalCooling",
+                "heating.circuits.1.operating.programs.normalCooling.demand": "cooling",
+                CIRCUIT_PUMP_FEATURE: "on",
+                COMPRESSOR_ACTIVE_FEATURE: True,
+                HEATING_DEMAND_FEATURE: "heating",
+            },
+            frozenset(),
+            None,
+            id="opposite-running-circuit-demand-is-unknown",
+        ),
+    ],
+)
+async def test_hvac_action(
+    mock_client: MockViClient,
+    feature_values: dict[str, object],
+    removed_feature_names: frozenset[str],
+    expected_action: HVACAction | None,
+) -> None:
+    """Test current HVAC action from authoritative Viessmann signals."""
+    # Arrange: Build a climate entity from the adjusted Vitocal250A signals.
+    entity = await _create_hvac_action_entity(
+        mock_client, feature_values, removed_feature_names
+    )
+
+    # Act: Resolve the circuit's current HVAC action.
+    action = entity.hvac_action
+
+    # Assert: Report only the action supported by the supplied signals.
+    assert action == expected_action
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## What changed

- Added `hvac_action` to Viessmann climate circuit entities.
- Derive defrosting, off, idle, heating, and cooling from authoritative Viessmann features.
- Treat missing or contradictory data conservatively and ignore non-authoritative heat signals such as the heating rod.
- Added 14 focused Vitocal250A-based test cases, including multi-circuit conflicts and heat/cool fallback behavior.

## Why

The climate entities exposed their configured HVAC mode but not the action currently being performed. Home Assistant therefore could not distinguish active heating or cooling from idle or unknown runtime states.

## Impact

Climate entities now expose a current HVAC action whenever the available device signals support an unambiguous result. No entities, config-flow behavior, or Thermoflow-specific logic were added.

## Validation

- `.venv/bin/ruff check .`
- `.venv/bin/ruff format --check .`
- `.venv/bin/python -m pytest -q` — 67 passed
- Discovery snapshot passed unchanged
