### PR TITLE
Repair OAuth reauthentication and token refresh handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ HACS and install the prerelease there before promoting it to a stable release.
 3. Search for "Viessmann Climate Devices"
 4. Follow the setup wizard:
    - You will be asked to enter your **Client ID** (from Viessmann Developer Portal)
-   - **Client Secret**: Enter any dummy value (e.g., `123`) since we use PKCE, but the field cannot be empty.
+   - **Client Secret**: Home Assistant requires a non-empty value, so enter any placeholder (for example `123`). The integration ignores it and never sends it to Viessmann because the OAuth flow uses PKCE without a client secret.
    - Perform the OAuth login to authorize with your Viessmann account
 
 ---
@@ -93,10 +93,13 @@ All entities are grouped under their respective device and support German and En
 
 ### Common Issues
 
+**"Bad Request" when refreshing a token**
+- Viessmann refresh tokens expire after 180 days. Home Assistant will then ask you to re-authenticate the existing integration.
+- Complete the re-authentication prompt to issue and store a new refresh token. You do not need to remove the integration or recreate its entities.
+
 **"Invalid Grant" or "Bad Request" during Login**
-This is often a timing issue with the OAuth code. 
-- **Solution:** Simply try the login process again. It usually works on the second attempt.
-- Ensure your browser clock is synchronized.
+- OAuth authorization codes are short-lived and can only be used once. Start a new re-authentication attempt instead of reopening an old callback URL.
+- Ensure your browser clock is synchronized and the login returns promptly to Home Assistant.
 
 **"Invalid redirect URI"**
 - Ensure `https://my.home-assistant.io/redirect/oauth` is added in Viessmann Developer Portal

--- a/custom_components/vi_climate_devices/__init__.py
+++ b/custom_components/vi_climate_devices/__init__.py
@@ -2,12 +2,10 @@
 
 from __future__ import annotations
 
-import logging
-
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import ConfigEntryAuthFailed
+from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
 from homeassistant.helpers import config_entry_oauth2_flow
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.config_entry_oauth2_flow import (
@@ -15,12 +13,10 @@ from homeassistant.helpers.config_entry_oauth2_flow import (
     OAuth2TokenRequestReauthError,
 )
 from vi_api_client import ViClient as ViessmannClient
-from vi_api_client.auth import AbstractAuth, ViAuthError
+from vi_api_client.auth import AbstractAuth
 
 from .const import DOMAIN
 from .coordinator import ViClimateDataUpdateCoordinator
-
-_LOGGER = logging.getLogger(__name__)
 
 PLATFORMS: list[Platform] = [
     Platform.BINARY_SENSOR,
@@ -58,8 +54,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             "OAuth refresh token rejected by Viessmann - re-authentication required"
         ) from err
     except OAuth2TokenRequestError as err:
-        _LOGGER.error("Error ensuring token validity: %s", err)
-        return False
+        raise ConfigEntryNotReady("Unable to refresh the Viessmann token") from err
 
     # Create the Auth Bridge
     auth = HAAuth(session)
@@ -98,10 +93,5 @@ class HAAuth(AbstractAuth):
 
     async def async_get_access_token(self) -> str:
         """Return a valid access token."""
-        try:
-            await self._session.async_ensure_token_valid()
-            return self._session.token["access_token"]
-        except OAuth2TokenRequestReauthError as err:
-            raise ViAuthError(f"OAuth refresh token expired or revoked: {err}") from err
-        except OAuth2TokenRequestError as err:
-            raise ViAuthError(f"Failed to refresh HA token: {err}") from err
+        await self._session.async_ensure_token_valid()
+        return self._session.token["access_token"]

--- a/custom_components/vi_climate_devices/application_credentials.py
+++ b/custom_components/vi_climate_devices/application_credentials.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-import logging
-
 from homeassistant.components.application_credentials import (
     AuthorizationServer,
     ClientCredential,
@@ -14,8 +12,6 @@ from homeassistant.helpers.config_entry_oauth2_flow import (
     LocalOAuth2ImplementationWithPkce,
 )
 from vi_api_client.const import ENDPOINT_AUTHORIZE, ENDPOINT_TOKEN
-
-_LOGGER = logging.getLogger(__name__)
 
 
 async def async_get_authorization_server(hass: HomeAssistant) -> AuthorizationServer:
@@ -30,17 +26,10 @@ async def async_get_auth_implementation(
     hass: HomeAssistant, auth_domain: str, credential: ClientCredential
 ) -> AbstractOAuth2Implementation:
     """Return auth implementation for a custom auth implementation."""
-    hass.data.setdefault(auth_domain, {})
-    cache = hass.data[auth_domain].setdefault("oauth_impls", {})
-
-    key = (auth_domain, credential.client_id, credential.client_secret)
-    if key not in cache:
-        cache[key] = LocalOAuth2ImplementationWithPkce(
-            hass,
-            auth_domain,
-            credential.client_id,
-            authorize_url=ENDPOINT_AUTHORIZE,
-            token_url=ENDPOINT_TOKEN,
-            client_secret=credential.client_secret,
-        )
-    return cache[key]
+    return LocalOAuth2ImplementationWithPkce(
+        hass,
+        auth_domain,
+        credential.client_id,
+        authorize_url=ENDPOINT_AUTHORIZE,
+        token_url=ENDPOINT_TOKEN,
+    )

--- a/custom_components/vi_climate_devices/config_flow.py
+++ b/custom_components/vi_climate_devices/config_flow.py
@@ -3,9 +3,10 @@
 from __future__ import annotations
 
 import logging
-from typing import Any
+from collections.abc import Mapping
 
-from homeassistant.config_entries import ConfigFlowResult
+import voluptuous as vol
+from homeassistant.config_entries import SOURCE_REAUTH, ConfigFlowResult
 from homeassistant.helpers import config_entry_oauth2_flow
 from vi_api_client.const import DEFAULT_SCOPES
 
@@ -26,40 +27,43 @@ class OAuth2FlowHandler(
         return logging.getLogger(__name__)
 
     @property
-    def extra_authorize_data(self) -> dict[str, Any]:
+    def extra_authorize_data(self) -> dict[str, str]:
         """Extra data that needs to be appended to the authorize url."""
         return {
             "scope": DEFAULT_SCOPES,
         }
 
-    async def async_step_reauth(self, entry_data: dict[str, Any]) -> ConfigFlowResult:
+    async def async_step_reauth(
+        self, entry_data: Mapping[str, object]
+    ) -> ConfigFlowResult:
         """Handle re-authentication when the refresh token is rejected."""
         return await self.async_step_reauth_confirm()
 
     async def async_step_reauth_confirm(
         self,
-        user_input: dict[str, Any] | None = None,
+        user_input: dict[str, object] | None = None,
     ) -> ConfigFlowResult:
         """Confirm re-authentication and restart the OAuth flow."""
         if user_input is None:
-            return self.async_show_form(step_id="reauth_confirm")
+            return self.async_show_form(
+                step_id="reauth_confirm",
+                data_schema=vol.Schema({}),
+            )
 
         return await self.async_step_pick_implementation(
             user_input={
-                "implementation": (
-                    self._get_reauth_entry().data.get("auth_implementation")
-                ),
+                "implementation": self._get_reauth_entry().data["auth_implementation"],
             },
         )
 
     async def async_oauth_create_entry(
         self,
-        data: dict[str, Any],
+        data: dict[str, object],
     ) -> ConfigFlowResult:
         """Create or update the config entry after OAuth authentication."""
-        if reauth_entry := self.reauth_entry:
+        if self.source == SOURCE_REAUTH:
             return self.async_update_reload_and_abort(
-                reauth_entry,
-                data=data,
+                self._get_reauth_entry(),
+                data_updates=data,
             )
         return await super().async_oauth_create_entry(data)

--- a/custom_components/vi_climate_devices/coordinator.py
+++ b/custom_components/vi_climate_devices/coordinator.py
@@ -6,12 +6,13 @@ import logging
 from datetime import timedelta
 
 from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import ConfigEntryAuthFailed
+from homeassistant.exceptions import ConfigEntryAuthFailed, OAuth2TokenRequestError
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 from vi_api_client import (
     Device,
     ViAuthError,
     ViClient as ViessmannClient,
+    ViError,
 )
 from vi_api_client.utils import mask_pii
 
@@ -20,7 +21,7 @@ from .const import DOMAIN, IGNORED_DEVICES
 _LOGGER = logging.getLogger(__name__)
 
 
-class ViClimateDataUpdateCoordinator(DataUpdateCoordinator):
+class ViClimateDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Device]]):
     """Class to manage fetching Viessmann data."""
 
     def __init__(
@@ -39,7 +40,7 @@ class ViClimateDataUpdateCoordinator(DataUpdateCoordinator):
         self.client = client
         self._known_devices: list[Device] = []
 
-    async def _perform_discovery(self):
+    async def _perform_discovery(self) -> None:
         """Perform initial device discovery.
 
         Fetches all installations and their devices/features to populate the
@@ -70,17 +71,19 @@ class ViClimateDataUpdateCoordinator(DataUpdateCoordinator):
             self._known_devices = [
                 device for device in all_devices if device.id not in IGNORED_DEVICES
             ]
+        except OAuth2TokenRequestError:
+            raise
         except ViAuthError as err:
             raise ConfigEntryAuthFailed(
                 f"Authentication failed during discovery: {err}"
             ) from err
-        except Exception as e:
-            raise UpdateFailed(f"Failed to perform full discovery: {e}") from e
+        except ViError as err:
+            raise UpdateFailed(f"Failed to perform full discovery: {err}") from err
 
         if not self._known_devices:
             _LOGGER.warning("No devices found during discovery")
 
-    async def _async_update_data(self) -> dict:
+    async def _async_update_data(self) -> dict[str, Device]:
         """Update data via library.
 
         Refreshes the state of all known devices.
@@ -107,13 +110,16 @@ class ViClimateDataUpdateCoordinator(DataUpdateCoordinator):
                         new_device = await self.client.update_device(device)
                         updated_data[key] = new_device
 
+                    except OAuth2TokenRequestError:
+                        raise
+
                     except ViAuthError as err:
                         # Trigger HA re-auth flow immediately
                         raise ConfigEntryAuthFailed(
                             f"Authentication failed for device {device.id}: {err}"
                         ) from err
 
-                    except Exception as err:
+                    except ViError as err:
                         _LOGGER.warning(
                             "Failed to update device %s: %s", device.id, err
                         )
@@ -127,7 +133,9 @@ class ViClimateDataUpdateCoordinator(DataUpdateCoordinator):
 
         except ConfigEntryAuthFailed:
             raise
+        except OAuth2TokenRequestError:
+            raise
         except ViAuthError as err:
             raise ConfigEntryAuthFailed(f"Authentication failed: {err}") from err
-        except Exception as exception:
-            raise UpdateFailed(exception) from exception
+        except ViError as err:
+            raise UpdateFailed(err) from err

--- a/custom_components/vi_climate_devices/strings.json
+++ b/custom_components/vi_climate_devices/strings.json
@@ -1,4 +1,7 @@
 {
+    "application_credentials": {
+        "description": "Enter your Viessmann client ID. Home Assistant requires a value in the client secret field; enter any placeholder. The integration ignores it because Viessmann uses PKCE without a client secret."
+    },
     "config": {
         "step": {
             "user": {

--- a/custom_components/vi_climate_devices/translations/de.json
+++ b/custom_components/vi_climate_devices/translations/de.json
@@ -1,4 +1,7 @@
 {
+    "application_credentials": {
+        "description": "Gib deine Viessmann Client-ID ein. Home Assistant verlangt einen Wert im Feld Client Secret; gib dort einen beliebigen Platzhalter ein. Die Integration ignoriert ihn, da Viessmann PKCE ohne Client Secret verwendet."
+    },
     "config": {
         "step": {
             "user": {

--- a/custom_components/vi_climate_devices/translations/en.json
+++ b/custom_components/vi_climate_devices/translations/en.json
@@ -1,4 +1,7 @@
 {
+    "application_credentials": {
+        "description": "Enter your Viessmann client ID. Home Assistant requires a value in the client secret field; enter any placeholder. The integration ignores it because Viessmann uses PKCE without a client secret."
+    },
     "config": {
         "step": {
             "user": {

--- a/tests/test_application_credentials.py
+++ b/tests/test_application_credentials.py
@@ -1,5 +1,7 @@
 """Tests for application credentials helpers."""
 
+from unittest.mock import AsyncMock, MagicMock, patch
+
 import pytest
 from homeassistant.components.application_credentials import ClientCredential
 from homeassistant.core import HomeAssistant
@@ -51,6 +53,88 @@ async def test_async_get_auth_implementation_returns_pkce_implementation(
     # Assert: The integration uses a PKCE-capable local OAuth implementation.
     assert isinstance(implementation, LocalOAuth2ImplementationWithPkce)
     assert implementation.client_id == "client-id"
-    assert implementation.client_secret == "client-secret"
+    assert implementation.client_secret == ""
     assert implementation.authorize_url == ENDPOINT_AUTHORIZE
     assert implementation.token_url == ENDPOINT_TOKEN
+
+
+@pytest.mark.asyncio
+async def test_async_get_auth_implementation_uses_fresh_pkce_verifier(
+    hass: HomeAssistant,
+) -> None:
+    """Test each OAuth flow receives a fresh PKCE verifier."""
+    # Arrange: Provide the same stored application credential for two flows.
+    credential = ClientCredential(
+        client_id="client-id",
+        client_secret="ignored-placeholder",
+        name="Viessmann",
+    )
+
+    # Act: Create two independent OAuth implementations.
+    first_implementation = await async_get_auth_implementation(
+        hass,
+        "vi_climate_devices",
+        credential,
+    )
+    second_implementation = await async_get_auth_implementation(
+        hass,
+        "vi_climate_devices",
+        credential,
+    )
+
+    # Assert: Each flow uses its own implementation and PKCE verifier.
+    assert first_implementation is not second_implementation
+    assert first_implementation.code_verifier != second_implementation.code_verifier
+
+
+@pytest.mark.asyncio
+async def test_refresh_request_omits_application_credential_secret(
+    hass: HomeAssistant,
+) -> None:
+    """Test a Viessmann refresh request never sends the HA placeholder secret."""
+    # Arrange: Build the PKCE implementation and a successful token response.
+    credential = ClientCredential(
+        client_id="client-id",
+        client_secret="ignored-placeholder",
+        name="Viessmann",
+    )
+    implementation = await async_get_auth_implementation(
+        hass,
+        "vi_climate_devices",
+        credential,
+    )
+    response = MagicMock(status=200)
+    response.json = AsyncMock(
+        return_value={
+            "access_token": "fresh-access-token",
+            "expires_in": 3600,
+        }
+    )
+    session = MagicMock()
+    session.post = AsyncMock(return_value=response)
+
+    with patch(
+        "homeassistant.helpers.config_entry_oauth2_flow.async_get_clientsession",
+        return_value=session,
+    ):
+        # Act: Refresh an expired access token through Home Assistant's helper.
+        refreshed_token = await implementation.async_refresh_token(
+            {
+                "access_token": "expired-access-token",
+                "expires_at": 0,
+                "expires_in": 3600,
+                "refresh_token": "refresh-token",
+            }
+        )
+
+    # Assert: The request matches Viessmann's public-client refresh contract.
+    session.post.assert_awaited_once_with(
+        ENDPOINT_TOKEN,
+        data={
+            "client_id": "client-id",
+            "grant_type": "refresh_token",
+            "refresh_token": "refresh-token",
+        },
+    )
+    assert refreshed_token["access_token"] == "fresh-access-token"
+    assert refreshed_token["refresh_token"] == "refresh-token"

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -97,6 +97,7 @@ async def test_reauth_flow_shows_confirm_form_and_redirects_to_oauth(
         domain=DOMAIN,
         data={
             "auth_implementation": "fake-provider",
+            "retained_setting": "keep-me",
             "token": {
                 "access_token": "expired-token",
                 "expires_at": 0,
@@ -126,6 +127,24 @@ async def test_reauth_flow_shows_confirm_form_and_redirects_to_oauth(
             user_input={},
         )
 
-    # Assert: The flow redirects to the external OAuth step.
+        # Act: Complete the external callback with a fresh authorization code.
+        callback_result = await hass.config_entries.flow.async_configure(
+            reauth_result["flow_id"],
+            user_input={"code": "fresh-code"},
+        )
+
+        # Act: Resolve the authorization code and persist the returned token.
+        creation_result = await hass.config_entries.flow.async_configure(
+            reauth_result["flow_id"],
+        )
+
+    # Assert: The flow redirects, updates the existing entry, and completes reauth.
     assert confirm_result["type"] is FlowResultType.EXTERNAL_STEP
     assert confirm_result["step_id"] == "auth"
+    assert callback_result["type"] is FlowResultType.EXTERNAL_STEP_DONE
+    assert creation_result["type"] is FlowResultType.ABORT
+    assert creation_result["reason"] == "reauth_successful"
+    assert entry.data["auth_implementation"] == "fake-provider"
+    assert entry.data["retained_setting"] == "keep-me"
+    assert entry.data["token"]["access_token"] == "token"
+    assert len(hass.config_entries.async_entries(DOMAIN)) == 1

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -1,13 +1,17 @@
 """Tests for coordinator discovery and refresh behavior."""
 
 from types import SimpleNamespace
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import ConfigEntryAuthFailed
+from homeassistant.exceptions import (
+    ConfigEntryAuthFailed,
+    OAuth2TokenRequestError,
+    OAuth2TokenRequestReauthError,
+)
 from homeassistant.helpers.update_coordinator import UpdateFailed
-from vi_api_client import Device, Feature, ViAuthError
+from vi_api_client import Device, Feature, ViAuthError, ViConnectionError
 
 from custom_components.vi_climate_devices.coordinator import (
     ViClimateDataUpdateCoordinator,
@@ -37,6 +41,30 @@ def _build_device(
                 is_ready=True,
             )
         ],
+    )
+
+
+def _make_reauth_error() -> OAuth2TokenRequestReauthError:
+    """Create a reauth-class OAuth token error."""
+    return OAuth2TokenRequestReauthError(
+        request_info=MagicMock(),
+        history=(),
+        status=400,
+        message="Bad Request",
+        headers=MagicMock(),
+        domain="vi_climate_devices",
+    )
+
+
+def _make_token_error() -> OAuth2TokenRequestError:
+    """Create a transient OAuth token error."""
+    return OAuth2TokenRequestError(
+        request_info=MagicMock(),
+        history=(),
+        status=500,
+        message="Internal Server Error",
+        headers=MagicMock(),
+        domain="vi_climate_devices",
     )
 
 
@@ -90,7 +118,9 @@ async def test_data_coordinator_keeps_last_device_state_when_refresh_fails(
     """Test refresh falls back to the previous immutable device when one update fails."""
     # Arrange: Seed one known device and make its refresh raise a transient error.
     known_device = _build_device(device_id="device-0", gateway_serial="gw-main")
-    mock_client.update_device = AsyncMock(side_effect=RuntimeError("device offline"))
+    mock_client.update_device = AsyncMock(
+        side_effect=ViConnectionError("device offline")
+    )
     coordinator = ViClimateDataUpdateCoordinator(hass, mock_client)
     coordinator._known_devices = [known_device]
 
@@ -116,3 +146,39 @@ async def test_data_coordinator_raises_reauth_when_device_update_loses_auth(
     # Act and Assert: The auth failure is escalated to Home Assistant reauth.
     with pytest.raises(ConfigEntryAuthFailed, match="token expired"):
         await coordinator._async_update_data()
+
+
+@pytest.mark.asyncio
+async def test_data_coordinator_propagates_oauth_reauth_error(
+    hass: HomeAssistant, mock_client
+) -> None:
+    """Test polling preserves an OAuth error that requires reauthentication."""
+    # Arrange: Seed a device and reject its refresh token during polling.
+    known_device = _build_device(device_id="device-0", gateway_serial="gw-main")
+    reauth_error = _make_reauth_error()
+    mock_client.update_device = AsyncMock(side_effect=reauth_error)
+    coordinator = ViClimateDataUpdateCoordinator(hass, mock_client)
+    coordinator._known_devices = [known_device]
+
+    # Act and Assert: Home Assistant receives the original reauth-class error.
+    with pytest.raises(OAuth2TokenRequestReauthError) as raised_error:
+        await coordinator._async_update_data()
+    assert raised_error.value is reauth_error
+
+
+@pytest.mark.asyncio
+async def test_data_coordinator_propagates_transient_oauth_error(
+    hass: HomeAssistant, mock_client
+) -> None:
+    """Test polling preserves a transient OAuth error for coordinator retry."""
+    # Arrange: Seed a device and simulate a temporary token endpoint failure.
+    known_device = _build_device(device_id="device-0", gateway_serial="gw-main")
+    token_error = _make_token_error()
+    mock_client.update_device = AsyncMock(side_effect=token_error)
+    coordinator = ViClimateDataUpdateCoordinator(hass, mock_client)
+    coordinator._known_devices = [known_device]
+
+    # Act and Assert: Home Assistant receives the original retryable error.
+    with pytest.raises(OAuth2TokenRequestError) as raised_error:
+        await coordinator._async_update_data()
+    assert raised_error.value is token_error

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -4,13 +4,12 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import ConfigEntryAuthFailed
+from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
 from homeassistant.helpers.config_entry_oauth2_flow import (
     OAuth2TokenRequestError,
     OAuth2TokenRequestReauthError,
 )
 from pytest_homeassistant_custom_component.common import MockConfigEntry
-from vi_api_client.auth import ViAuthError
 
 from custom_components.vi_climate_devices import (
     PLATFORMS,
@@ -85,10 +84,10 @@ async def test_async_setup_entry_raises_config_entry_auth_failed_on_reauth_error
 
 
 @pytest.mark.asyncio
-async def test_async_setup_entry_returns_false_on_transient_token_error(
+async def test_async_setup_entry_raises_not_ready_on_transient_token_error(
     hass: HomeAssistant,
 ) -> None:
-    """Test setup returns False on non-reauth token errors without raising."""
+    """Test setup schedules a retry for a transient OAuth token error."""
     # Arrange: Register a config entry and force a transient token error.
     entry = _build_entry()
     entry.add_to_hass(hass)
@@ -102,12 +101,12 @@ async def test_async_setup_entry_returns_false_on_transient_token_error(
             "homeassistant.helpers.config_entry_oauth2_flow.OAuth2Session.async_ensure_token_valid",
             side_effect=_make_token_error(),
         ),
+        pytest.raises(ConfigEntryNotReady),
     ):
-        # Act: Attempt to set up the integration entry.
-        result = await async_setup_entry(hass, entry)
+        # Act: Attempt to set up the integration while OAuth is unavailable.
+        await async_setup_entry(hass, entry)
 
-    # Assert: Setup fails gracefully without raising.
-    assert result is False
+    # Assert: Setup leaves no runtime data while Home Assistant schedules a retry.
     assert hass.data[DOMAIN] == {}
 
 
@@ -232,16 +231,17 @@ async def test_haauth_async_get_access_token_returns_refreshed_token(
 
 
 @pytest.mark.asyncio
-async def test_haauth_wraps_reauth_error_as_vi_auth_error(
+async def test_haauth_propagates_reauth_token_error(
     hass: HomeAssistant,
 ) -> None:
-    """Test the auth bridge wraps reauth-class errors as ViAuthError for the client."""
+    """Test the auth bridge preserves a reauth-class OAuth error."""
     # Arrange: Provide a session that fails with a reauth-class error.
+    reauth_error = _make_reauth_error()
     oauth_session = MagicMock()
     oauth_session.hass = hass
     oauth_session.token = {"access_token": "stale-token"}
     oauth_session.async_ensure_token_valid = AsyncMock(
-        side_effect=_make_reauth_error(),
+        side_effect=reauth_error,
     )
 
     with patch(
@@ -250,22 +250,24 @@ async def test_haauth_wraps_reauth_error_as_vi_auth_error(
     ):
         auth_bridge = HAAuth(oauth_session)
 
-    # Act and Assert: The client receives a ViAuthError with the original context.
-    with pytest.raises(ViAuthError, match="expired or revoked"):
+    # Act and Assert: The coordinator can classify the original reauth error.
+    with pytest.raises(OAuth2TokenRequestReauthError) as raised_error:
         await auth_bridge.async_get_access_token()
+    assert raised_error.value is reauth_error
 
 
 @pytest.mark.asyncio
-async def test_haauth_wraps_token_error_as_vi_auth_error(
+async def test_haauth_propagates_transient_token_error(
     hass: HomeAssistant,
 ) -> None:
-    """Test the auth bridge wraps transient token errors as ViAuthError for the client."""
+    """Test the auth bridge preserves a transient OAuth token error."""
     # Arrange: Provide a session that fails with a transient token error.
+    token_error = _make_token_error()
     oauth_session = MagicMock()
     oauth_session.hass = hass
     oauth_session.token = {"access_token": "stale-token"}
     oauth_session.async_ensure_token_valid = AsyncMock(
-        side_effect=_make_token_error(),
+        side_effect=token_error,
     )
 
     with patch(
@@ -274,6 +276,7 @@ async def test_haauth_wraps_token_error_as_vi_auth_error(
     ):
         auth_bridge = HAAuth(oauth_session)
 
-    # Act and Assert: The client receives a ViAuthError with the refresh failure message.
-    with pytest.raises(ViAuthError, match="Failed to refresh HA token"):
+    # Act and Assert: The coordinator can classify the original transient error.
+    with pytest.raises(OAuth2TokenRequestError) as raised_error:
         await auth_bridge.async_get_access_token()
+    assert raised_error.value is token_error


### PR DESCRIPTION
## What changed

- create a fresh PKCE implementation for each OAuth flow and omit the Home Assistant placeholder client secret from Viessmann token requests
- update the reauthentication callback to use the current Home Assistant config-flow APIs while preserving existing config-entry data
- preserve Home Assistant OAuth error types so rejected refresh tokens trigger reauthentication and transient token errors remain retryable
- document Viessmann's 180-day refresh-token lifetime and clarify the application-credentials setup
- add coverage for the complete OAuth callback, refresh request payload, fresh PKCE verifiers, and coordinator error classification

## Why

Viessmann refresh tokens expire after 180 days. The reauthentication flow could obtain a fresh token, but then crashed while accessing the removed `reauth_entry` attribute, so the token was never stored. The cached PKCE implementation and forwarded placeholder secret also diverged from the public-client OAuth contract.

## Impact

Expired Viessmann credentials can be renewed through Home Assistant without removing the integration or recreating entities. Temporary OAuth endpoint failures are retried instead of incorrectly forcing reauthentication.

## Validation

- `ruff check .`
- `ruff format --check .`
- `python -m pytest -q` — 74 passed
- integration JSON and manifest validation
