### PR TITLE
Bump version to 1.4.0-beta.3

### DIFF
--- a/custom_components/vi_climate_devices/manifest.json
+++ b/custom_components/vi_climate_devices/manifest.json
@@ -15,5 +15,5 @@
   "requirements": [
     "vi_api_client @ git+https://github.com/ignazhabibi/vi_api_client.git@v1.3.0"
   ],
-  "version": "1.4.0-beta.2"
+  "version": "1.4.0-beta.3"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vi_climate_devices"
-version = "1.4.0-beta.2"
+version = "1.4.0-beta.3"
 description = "Viessmann Climate Devices Integration for Home Assistant"
 authors = [
   { name = "Michael", email = "notme@bieber-home.net" },


### PR DESCRIPTION
## What changed

- Bump the integration version from `1.4.0-beta.2` to `1.4.0-beta.3` in both release version sources.

## Why

`1.4.0-beta.3` publishes the OAuth reauthentication fix merged in #65. The fix restores reauthentication after Viessmann refresh-token expiry while preserving the existing Home Assistant config entry and using the public-client PKCE token exchange without a client secret.

## Impact

Users can install the third beta to verify the corrected Viessmann OAuth refresh and reauthentication behavior.

## Validation

- `ruff check .`
- `ruff format --check .`
- `python -m pytest -q` — 74 passed, 1 snapshot passed
- Fresh Python 3.14 environment installed with `.[dev]` and the same checks repeated successfully
