### PR TITLE
Bump version to 1.4.0

### DIFF
--- a/custom_components/vi_climate_devices/manifest.json
+++ b/custom_components/vi_climate_devices/manifest.json
@@ -15,5 +15,5 @@
   "requirements": [
     "vi_api_client @ git+https://github.com/ignazhabibi/vi_api_client.git@v1.3.0"
   ],
-  "version": "1.4.0-beta.3"
+  "version": "1.4.0"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vi_climate_devices"
-version = "1.4.0-beta.3"
+version = "1.4.0"
 description = "Viessmann Climate Devices Integration for Home Assistant"
 authors = [
   { name = "Michael", email = "notme@bieber-home.net" },


### PR DESCRIPTION
## What changed

- Promote the successfully tested `1.4.0-beta.3` build to the stable `1.4.0` release.
- Align both release version sources in `manifest.json` and `pyproject.toml`.

## Why

The 1.4.0 beta series added and hardened Home Assistant reauthentication for expired or rejected Viessmann refresh tokens. Beta 3 was verified successfully against a live Home Assistant installation.

## Impact

Users can recover an existing integration after Viessmann authentication expires without deleting and recreating their Home Assistant config entry. OAuth uses Viessmann's public-client PKCE flow without a client secret.

## Validation

- Live reauthentication completed successfully with `v1.4.0-beta.3`
- `ruff check .`
- `ruff format --check .`
- `python -m pytest -q` — 74 passed, 1 snapshot passed
- Fresh Python 3.14 environment installed with `.[dev]` and the same checks repeated successfully
