### PR TITLE
chore: release v1.4.1

### DIFF
--- a/custom_components/vi_climate_devices/manifest.json
+++ b/custom_components/vi_climate_devices/manifest.json
@@ -15,5 +15,5 @@
   "requirements": [
     "vi_api_client @ git+https://github.com/ignazhabibi/vi_api_client.git@v1.3.2"
   ],
-  "version": "1.4.0"
+  "version": "1.4.1"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vi_climate_devices"
-version = "1.4.0"
+version = "1.4.1"
 description = "Viessmann Climate Devices Integration for Home Assistant"
 authors = [
   { name = "Michael", email = "notme@bieber-home.net" },


### PR DESCRIPTION
## Description
Release `v1.4.1` containing dependency and tooling updates.

### Changes
- Update dependency `pytest-homeassistant-custom-component` to v0.13.363 (#58, #70, #72)
- Update dependency `ruff` to v0.16.6 (#59, #68, #73)
- Update `vi_api_client` to v1.3.2 (#69, #71)
- Update `actions/setup-python` action to v7 (#57)