### PR TITLE
Resolve Pylance typing diagnostics

### DIFF
--- a/custom_components/vi_climate_devices/utils.py
+++ b/custom_components/vi_climate_devices/utils.py
@@ -5,7 +5,7 @@ from collections.abc import Sequence
 from typing import Any
 
 
-def beautify_name(name: str) -> str:
+def beautify_name(name: str | None) -> str | None:
     """Convert a dot-separated name to a Title Cased string.
 
     Removes leading 'heating.' if present.
@@ -94,13 +94,13 @@ def get_feature_bool_value(value: Any, strict: bool = False) -> bool | None:
 
 def is_feature_ignored(
     feature_name: str,
-    ignored_features: Sequence[str | re.Pattern],
+    ignored_features: Sequence[str | re.Pattern[str]],
 ) -> bool:
     """Check if a feature should be ignored based on list of patterns."""
     for pattern in ignored_features:
         if isinstance(pattern, str) and feature_name == pattern:
             return True
-        if hasattr(pattern, "match") and pattern.match(feature_name):
+        if isinstance(pattern, re.Pattern) and pattern.match(feature_name):
             return True
     return False
 

--- a/tests/test_application_credentials.py
+++ b/tests/test_application_credentials.py
@@ -83,6 +83,8 @@ async def test_async_get_auth_implementation_uses_fresh_pkce_verifier(
     )
 
     # Assert: Each flow uses its own implementation and PKCE verifier.
+    assert isinstance(first_implementation, LocalOAuth2ImplementationWithPkce)
+    assert isinstance(second_implementation, LocalOAuth2ImplementationWithPkce)
     assert first_implementation is not second_implementation
     assert first_implementation.code_verifier != second_implementation.code_verifier
 

--- a/tests/test_climate.py
+++ b/tests/test_climate.py
@@ -3,18 +3,16 @@
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-from homeassistant.components.climate import (
-    SERVICE_SET_HVAC_MODE,
-    SERVICE_SET_PRESET_MODE,
-    SERVICE_SET_TEMPERATURE,
-    HVACAction,
-    HVACMode,
-)
 from homeassistant.components.climate.const import (
     PRESET_COMFORT,
     PRESET_ECO,
     PRESET_HOME,
     PRESET_SLEEP,
+    SERVICE_SET_HVAC_MODE,
+    SERVICE_SET_PRESET_MODE,
+    SERVICE_SET_TEMPERATURE,
+    HVACAction,
+    HVACMode,
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
@@ -398,6 +396,7 @@ async def test_climate_error_handling_and_rollback(
 
         entity_id = "climate.vitocal250a_heating_circuit_0"
         state = hass.states.get(entity_id)
+        assert state is not None
         original_temp = float(state.attributes["temperature"])
 
         # Act: Set temperature to 25.0 (should fail).

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -78,11 +78,13 @@ async def test_user_flow_shows_picker_and_starts_external_step(
         )
 
     # Assert: The flow shows the picker first and then redirects to OAuth auth.
-    assert start_result["type"] is FlowResultType.FORM
-    assert start_result["step_id"] == "pick_implementation"
-    assert auth_result["type"] is FlowResultType.EXTERNAL_STEP
-    assert auth_result["step_id"] == "auth"
-    authorize_url = URL(auth_result["url"])
+    assert start_result.get("type") is FlowResultType.FORM
+    assert start_result.get("step_id") == "pick_implementation"
+    assert auth_result.get("type") is FlowResultType.EXTERNAL_STEP
+    assert auth_result.get("step_id") == "auth"
+    url = auth_result.get("url")
+    assert url is not None
+    authorize_url = URL(url)
     assert authorize_url.query["existing"] == "1"
     assert authorize_url.query["scope"] == DEFAULT_SCOPES
 
@@ -118,8 +120,8 @@ async def test_reauth_flow_shows_confirm_form_and_redirects_to_oauth(
         reauth_result = await entry.start_reauth_flow(hass)
 
         # Assert: The first step shows the reauth confirmation form.
-        assert reauth_result["type"] is FlowResultType.FORM
-        assert reauth_result["step_id"] == "reauth_confirm"
+        assert reauth_result.get("type") is FlowResultType.FORM
+        assert reauth_result.get("step_id") == "reauth_confirm"
 
         # Act: User confirms the reauth form.
         confirm_result = await hass.config_entries.flow.async_configure(
@@ -139,11 +141,11 @@ async def test_reauth_flow_shows_confirm_form_and_redirects_to_oauth(
         )
 
     # Assert: The flow redirects, updates the existing entry, and completes reauth.
-    assert confirm_result["type"] is FlowResultType.EXTERNAL_STEP
-    assert confirm_result["step_id"] == "auth"
-    assert callback_result["type"] is FlowResultType.EXTERNAL_STEP_DONE
-    assert creation_result["type"] is FlowResultType.ABORT
-    assert creation_result["reason"] == "reauth_successful"
+    assert confirm_result.get("type") is FlowResultType.EXTERNAL_STEP
+    assert confirm_result.get("step_id") == "auth"
+    assert callback_result.get("type") is FlowResultType.EXTERNAL_STEP_DONE
+    assert creation_result.get("type") is FlowResultType.ABORT
+    assert creation_result.get("reason") == "reauth_successful"
     assert entry.data["auth_implementation"] == "fake-provider"
     assert entry.data["retained_setting"] == "keep-me"
     assert entry.data["token"]["access_token"] == "token"

--- a/tests/test_discovery_snapshot.py
+++ b/tests/test_discovery_snapshot.py
@@ -5,7 +5,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 from homeassistant.core import HomeAssistant
 from pytest_homeassistant_custom_component.common import MockConfigEntry
-from syrupy import SnapshotAssertion
+from syrupy.assertion import SnapshotAssertion
 
 from custom_components.vi_climate_devices.const import DOMAIN
 

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -4,8 +4,9 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
-from homeassistant.helpers.config_entry_oauth2_flow import (
+from homeassistant.exceptions import (
+    ConfigEntryAuthFailed,
+    ConfigEntryNotReady,
     OAuth2TokenRequestError,
     OAuth2TokenRequestReauthError,
 )

--- a/tests/test_number.py
+++ b/tests/test_number.py
@@ -3,7 +3,7 @@
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-from homeassistant.components.number import (
+from homeassistant.components.number.const import (
     ATTR_MAX,
     ATTR_MIN,
     ATTR_STEP,
@@ -70,8 +70,10 @@ async def test_number_creation_and_services(hass: HomeAssistant, mock_client):
 
         # Verify precision on entity
         component = hass.data.get("number")
+        assert component is not None
         entity_id = "number.vitocal250a_heating_circuit_0_curve_slope"
         entity = component.get_entity(entity_id)
+        assert entity is not None
         assert entity.suggested_display_precision == 1
 
         # Act: Set slope to 1.6.

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -179,7 +179,7 @@ async def test_auto_discovery_unit_mapping(hass: HomeAssistant, mock_client):
     mock_device = Device(
         id="0",
         gateway_serial="mock_gateway",
-        installation_id=123,
+        installation_id="123",
         features=[
             feat_celsius,
             feat_bar,

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -89,6 +89,7 @@ async def test_switch_creation_and_services(hass: HomeAssistant, mock_client):
         # Verify Optimistic State Update.
         # The switch should match the requested state immediately.
         one_time_charge = hass.states.get("switch.vitocal250a_one_time_dhw_charge")
+        assert one_time_charge is not None
         assert one_time_charge.state == "on"
 
         # Test 3: Service Calls (turn_off).
@@ -112,6 +113,7 @@ async def test_switch_creation_and_services(hass: HomeAssistant, mock_client):
 
         # Verify Optimistic State Update.
         one_time_charge = hass.states.get("switch.vitocal250a_one_time_dhw_charge")
+        assert one_time_charge is not None
         assert one_time_charge.state == STATE_OFF
 
         await hass.config_entries.async_unload(entry.entry_id)

--- a/tests/test_water_heater.py
+++ b/tests/test_water_heater.py
@@ -76,7 +76,9 @@ async def test_water_heater_creation_and_services(hass: HomeAssistant, mock_clie
         assert state.attributes["max_temp"] == 60.0
         # Verify constraints on entity
         component = hass.data.get("water_heater")
+        assert component is not None
         entity = component.get_entity(entity_id)
+        assert entity is not None
         # Use getattr because property might not exist in all HA versions
         assert (
             getattr(entity, "target_temperature_step", None) == 1.0
@@ -109,6 +111,7 @@ async def test_water_heater_creation_and_services(hass: HomeAssistant, mock_clie
 
         # Verify Optimistic Update (Temp).
         state = hass.states.get(entity_id)
+        assert state is not None
         assert float(state.attributes["temperature"]) == 45.0
 
         # Reset Mock.
@@ -132,6 +135,7 @@ async def test_water_heater_creation_and_services(hass: HomeAssistant, mock_clie
 
         # Verify Optimistic Update (Mode).
         state = hass.states.get(entity_id)
+        assert state is not None
         assert state.state == STATE_PERFORMANCE
 
         await hass.config_entries.async_unload(entry.entry_id)
@@ -171,6 +175,7 @@ async def test_water_heater_error_handling(hass: HomeAssistant, mock_client):
 
         entity_id = "water_heater.vitocal250a_dhw_water_heater"
         state = hass.states.get(entity_id)
+        assert state is not None
         original_temp = float(state.attributes["temperature"])
 
         # Act: Try to set temperature (Should fail).
@@ -184,7 +189,7 @@ async def test_water_heater_error_handling(hass: HomeAssistant, mock_client):
 
         # Assert: Rollback occurred.
         state = hass.states.get(entity_id)
-        state = hass.states.get(entity_id)
+        assert state is not None
         assert float(state.attributes["temperature"]) == original_temp
 
         await hass.config_entries.async_unload(entry.entry_id)
@@ -226,6 +231,7 @@ async def test_water_heater_api_rejection(hass: HomeAssistant, mock_client):
 
         entity_id = "water_heater.vitocal250a_dhw_water_heater"
         state = hass.states.get(entity_id)
+        assert state is not None
         original_temp = float(state.attributes["temperature"])
 
         # Act: Try to set temperature.
@@ -239,6 +245,7 @@ async def test_water_heater_api_rejection(hass: HomeAssistant, mock_client):
 
         # Assert: Rollback occurred.
         state = hass.states.get(entity_id)
+        assert state is not None
         assert float(state.attributes["temperature"]) == original_temp
 
         await hass.config_entries.async_unload(entry.entry_id)


### PR DESCRIPTION
## What changed

- Refined utility type annotations for optional feature names and compiled ignore patterns.
- Updated Home Assistant and test dependency imports to their concrete modules.
- Added explicit type narrowing in tests and aligned fixture data with the client model types.

## Why

- Resolve Pylance diagnostics without changing the integration's intended behavior.
- Keep the test suite aligned with current Home Assistant and dependency type definitions.

## Impact

- No intended functional behavior change.
- Static type analysis is clearer and tests now assert optional values before using them.

## Validation

- `ruff check .`
- `ruff format --check .`
- `python -m pytest -q` — 74 passed, 1 snapshot passed
- Integration manifest parsed as valid JSON
