### PR TITLE
Release v1.4.2

### DIFF
--- a/custom_components/vi_climate_devices/manifest.json
+++ b/custom_components/vi_climate_devices/manifest.json
@@ -15,5 +15,5 @@
   "requirements": [
     "vi_api_client @ git+https://github.com/ignazhabibi/vi_api_client.git@v1.3.2"
   ],
-  "version": "1.4.1"
+  "version": "1.4.2"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vi_climate_devices"
-version = "1.4.1"
+version = "1.4.2"
 description = "Viessmann Climate Devices Integration for Home Assistant"
 authors = [
   { name = "Michael", email = "notme@bieber-home.net" },


### PR DESCRIPTION
## What changed

- Bumped the integration version from `1.4.1` to `1.4.2` in `manifest.json`.
- Kept the package metadata version in `pyproject.toml` aligned at `1.4.2`.

## Why

- Prepare the stable patch release containing the fixes merged in PRs #75, #76, and #77.

## Impact

- Release metadata only; no additional runtime behavior changes.

## Validation

- `ruff check .`
- `ruff format --check .`
- `python -m pytest -q` — 74 passed, 1 snapshot passed
- Fresh Python 3.14 environment installed successfully with `.[dev]`
- The same lint, format, and test gates passed in the fresh environment
- Manifest is valid JSON and both version sources resolve to `1.4.2`
