### PR TITLE
Update vi_api_client to v1.3.3

### DIFF
--- a/custom_components/vi_climate_devices/manifest.json
+++ b/custom_components/vi_climate_devices/manifest.json
@@ -13,7 +13,7 @@
     "vi_api_client"
   ],
   "requirements": [
-    "vi_api_client @ git+https://github.com/ignazhabibi/vi_api_client.git@v1.3.2"
+    "vi_api_client @ git+https://github.com/ignazhabibi/vi_api_client.git@v1.3.3"
   ],
   "version": "1.4.2"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ classifiers = [
 ]
 requires-python = ">=3.14"
 dependencies = [
-    "vi_api_client @ git+https://github.com/ignazhabibi/vi_api_client.git@v1.3.2",
+    "vi_api_client @ git+https://github.com/ignazhabibi/vi_api_client.git@v1.3.3",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## What changed

- Updated the `vi_api_client` dependency from v1.3.2 to v1.3.3 in package metadata and the Home Assistant manifest.

## Why

- v1.3.3 lets Home Assistant OAuth token-request errors propagate correctly so DataUpdateCoordinator can trigger reauthentication when required.

## Impact

- Resolves token reauthentication handling during runtime without changing integration behavior or configuration.

## Validation

- Installed `.[dev]` in a fresh Python 3.14 environment; resolved `vi_api_client` 1.3.3 at commit `0049227`.
- `ruff format .`
- `ruff check --fix custom_components/vi_climate_devices tests`
- `pytest tests/` — 74 passed, 1 snapshot passed.
- Manifest JSON validation.