### PR TITLE
Release v1.4.3

### DIFF
--- a/custom_components/vi_climate_devices/manifest.json
+++ b/custom_components/vi_climate_devices/manifest.json
@@ -15,5 +15,5 @@
   "requirements": [
     "vi_api_client @ git+https://github.com/ignazhabibi/vi_api_client.git@v1.3.3"
   ],
-  "version": "1.4.2"
+  "version": "1.4.3"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vi_climate_devices"
-version = "1.4.2"
+version = "1.4.3"
 description = "Viessmann Climate Devices Integration for Home Assistant"
 authors = [
   { name = "Michael", email = "notme@bieber-home.net" },


### PR DESCRIPTION
## What changed

- Prepared release v1.4.3.
- Includes the `vi_api_client` v1.3.3 update from PR #79.

## Why

- v1.3.3 preserves Home Assistant OAuth token-request errors so reauthentication can start when a refresh token is no longer valid.

## Impact

- Runtime OAuth reauthentication is handled correctly after upgrading. No configuration changes are required.

## Validation

- Release versions are aligned in `manifest.json` and `pyproject.toml`.
- `ruff check .`
- `ruff format --check .`
- `pytest -q` — 74 passed, 1 snapshot passed.