### PR TITLE
Mark failed device updates unavailable

### DIFF
--- a/custom_components/vi_climate_devices/binary_sensor.py
+++ b/custom_components/vi_climate_devices/binary_sensor.py
@@ -16,11 +16,11 @@ from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from vi_api_client.api import Feature
 
 from .const import DOMAIN, IGNORED_FEATURES, TESTED_DEVICES
 from .coordinator import ViClimateDataUpdateCoordinator
+from .entity import ViClimateEntity
 from .utils import (
     beautify_name,
     get_feature_bool_value,
@@ -210,9 +210,7 @@ async def async_setup_entry(
     async_add_entities(entities)
 
 
-class ViClimateBinarySensor(
-    CoordinatorEntity[ViClimateDataUpdateCoordinator], BinarySensorEntity
-):
+class ViClimateBinarySensor(ViClimateEntity, BinarySensorEntity):
     """Representation of a generic Viessmann Climate Devices Binary Sensor."""
 
     def __init__(  # noqa: PLR0913, PLR0917
@@ -289,4 +287,4 @@ class ViClimateBinarySensor(
     def available(self) -> bool:
         """Return True if entity is available."""
         feat = self.feature_data
-        return self.coordinator.last_update_success and feat and feat.is_enabled
+        return super().available and feat is not None and feat.is_enabled

--- a/custom_components/vi_climate_devices/climate.py
+++ b/custom_components/vi_climate_devices/climate.py
@@ -24,11 +24,11 @@ from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from vi_api_client import Feature
 
 from .const import DOMAIN
 from .coordinator import ViClimateDataUpdateCoordinator
+from .entity import ViClimateEntity
 from .utils import get_suggested_precision
 
 _LOGGER = logging.getLogger(__name__)
@@ -117,7 +117,7 @@ async def async_setup_entry(
     async_add_entities(entities)
 
 
-class ViClimate(CoordinatorEntity[ViClimateDataUpdateCoordinator], ClimateEntity):
+class ViClimate(ViClimateEntity, ClimateEntity):
     """Representation of a Viessmann climate circuit."""
 
     _attr_temperature_unit = UnitOfTemperature.CELSIUS

--- a/custom_components/vi_climate_devices/coordinator.py
+++ b/custom_components/vi_climate_devices/coordinator.py
@@ -39,6 +39,11 @@ class ViClimateDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Device]]):
         )
         self.client = client
         self._known_devices: list[Device] = []
+        self._failed_device_keys: set[str] = set()
+
+    def is_device_available(self, device_key: str) -> bool:
+        """Return whether the most recent refresh succeeded for a device."""
+        return device_key not in self._failed_device_keys
 
     async def _perform_discovery(self) -> None:
         """Perform initial device discovery.
@@ -101,6 +106,7 @@ class ViClimateDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Device]]):
 
             # 2. Update Loop (Refresh each device)
             updated_data: dict[str, Device] = {}
+            failed_device_keys: set[str] = set()
 
             if self._known_devices:
                 _LOGGER.debug("Updating %s known devices", len(self._known_devices))
@@ -123,8 +129,13 @@ class ViClimateDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Device]]):
                         _LOGGER.warning(
                             "Failed to update device %s: %s", device.id, err
                         )
-                        # Graceful degradation: keep old data so entities stay available
+                        failed_device_keys.add(key)
+                        # Keep old data for recovery, but mark its entities unavailable.
                         updated_data[key] = device
+
+                self._failed_device_keys = failed_device_keys
+                if failed_device_keys and len(failed_device_keys) == len(updated_data):
+                    raise UpdateFailed("Failed to update all devices")
 
                 # Update local reference with fresh immutable objects
                 self._known_devices = list(updated_data.values())

--- a/custom_components/vi_climate_devices/entity.py
+++ b/custom_components/vi_climate_devices/entity.py
@@ -1,0 +1,16 @@
+"""Shared entity behavior for Viessmann Climate Devices."""
+
+from __future__ import annotations
+
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from .coordinator import ViClimateDataUpdateCoordinator
+
+
+class ViClimateEntity(CoordinatorEntity[ViClimateDataUpdateCoordinator]):
+    """Base entity that reflects per-device refresh availability."""
+
+    @property
+    def available(self) -> bool:
+        """Return whether the coordinator has current data for this device."""
+        return super().available and self.coordinator.is_device_available(self._map_key)

--- a/custom_components/vi_climate_devices/number.py
+++ b/custom_components/vi_climate_devices/number.py
@@ -19,11 +19,11 @@ from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from vi_api_client import Feature
 
 from .const import DOMAIN, IGNORED_FEATURES, TESTED_DEVICES
 from .coordinator import ViClimateDataUpdateCoordinator
+from .entity import ViClimateEntity
 from .utils import beautify_name, get_suggested_precision, is_feature_ignored
 
 _LOGGER = logging.getLogger(__name__)
@@ -245,7 +245,7 @@ async def async_setup_entry(
     async_add_entities(entities)
 
 
-class ViClimateNumber(CoordinatorEntity[ViClimateDataUpdateCoordinator], NumberEntity):
+class ViClimateNumber(ViClimateEntity, NumberEntity):
     """Representation of a Viessmann Climate Devices Number Entity."""
 
     entity_description: NumberEntityDescription

--- a/custom_components/vi_climate_devices/select.py
+++ b/custom_components/vi_climate_devices/select.py
@@ -13,11 +13,11 @@ from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from vi_api_client import Feature
 
 from .const import DOMAIN, IGNORED_FEATURES, TESTED_DEVICES
 from .coordinator import ViClimateDataUpdateCoordinator
+from .entity import ViClimateEntity
 from .utils import beautify_name, is_feature_ignored
 
 _LOGGER = logging.getLogger(__name__)
@@ -137,7 +137,7 @@ async def async_setup_entry(
     async_add_entities(entities)
 
 
-class ViClimateSelect(CoordinatorEntity[ViClimateDataUpdateCoordinator], SelectEntity):
+class ViClimateSelect(ViClimateEntity, SelectEntity):
     """Representation of a Viessmann Climate Devices Select Entity."""
 
     entity_description: SelectEntityDescription

--- a/custom_components/vi_climate_devices/sensor.py
+++ b/custom_components/vi_climate_devices/sensor.py
@@ -26,11 +26,11 @@ from homeassistant.const import (
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from vi_api_client.api import Feature
 
 from .const import DOMAIN, IGNORED_FEATURES, TESTED_DEVICES
 from .coordinator import ViClimateDataUpdateCoordinator
+from .entity import ViClimateEntity
 from .utils import beautify_name, is_feature_boolean_like, is_feature_ignored
 
 _LOGGER = logging.getLogger(__name__)
@@ -759,7 +759,7 @@ def _discover_realtime_sensors(
     return entities
 
 
-class ViClimateSensor(CoordinatorEntity[ViClimateDataUpdateCoordinator], SensorEntity):
+class ViClimateSensor(ViClimateEntity, SensorEntity):
     """Representation of a generic Viessmann Climate Devices Sensor."""
 
     def __init__(  # noqa: PLR0913, PLR0917
@@ -857,8 +857,4 @@ class ViClimateSensor(CoordinatorEntity[ViClimateDataUpdateCoordinator], SensorE
     def available(self) -> bool:
         """Return True if entity is available."""
         feat = self.feature_data
-        return (
-            self.coordinator.last_update_success
-            and feat is not None
-            and feat.is_enabled
-        )
+        return super().available and feat is not None and feat.is_enabled

--- a/custom_components/vi_climate_devices/switch.py
+++ b/custom_components/vi_climate_devices/switch.py
@@ -16,11 +16,11 @@ from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from vi_api_client import Feature
 
 from .const import DOMAIN, IGNORED_FEATURES, TESTED_DEVICES
 from .coordinator import ViClimateDataUpdateCoordinator
+from .entity import ViClimateEntity
 from .utils import (
     beautify_name,
     get_feature_bool_value,
@@ -101,7 +101,7 @@ async def async_setup_entry(
     async_add_entities(entities)
 
 
-class ViClimateSwitch(CoordinatorEntity[ViClimateDataUpdateCoordinator], SwitchEntity):
+class ViClimateSwitch(ViClimateEntity, SwitchEntity):
     """Representation of a Viessmann Climate Devices Switch Entity."""
 
     entity_description: SwitchEntityDescription

--- a/custom_components/vi_climate_devices/water_heater.py
+++ b/custom_components/vi_climate_devices/water_heater.py
@@ -20,11 +20,11 @@ from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from vi_api_client import Feature
 
 from .const import DOMAIN
 from .coordinator import ViClimateDataUpdateCoordinator
+from .entity import ViClimateEntity
 from .utils import get_suggested_precision
 
 _LOGGER = logging.getLogger(__name__)
@@ -85,9 +85,7 @@ async def async_setup_entry(
     async_add_entities(entities)
 
 
-class ViClimateWaterHeater(
-    CoordinatorEntity[ViClimateDataUpdateCoordinator], WaterHeaterEntity
-):
+class ViClimateWaterHeater(ViClimateEntity, WaterHeaterEntity):
     """Representation of a Viessmann Water Heater."""
 
     _attr_translation_key = "dhw_water_heater"

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -112,10 +112,10 @@ async def test_data_coordinator_discovers_devices_and_filters_ignored_ids(
 
 
 @pytest.mark.asyncio
-async def test_data_coordinator_keeps_last_device_state_when_refresh_fails(
+async def test_data_coordinator_raises_when_all_device_updates_fail(
     hass: HomeAssistant, mock_client
 ) -> None:
-    """Test refresh falls back to the previous immutable device when one update fails."""
+    """Test refresh fails when no known device can be updated."""
     # Arrange: Seed one known device and make its refresh raise a transient error.
     known_device = _build_device(device_id="device-0", gateway_serial="gw-main")
     mock_client.update_device = AsyncMock(
@@ -124,12 +124,40 @@ async def test_data_coordinator_keeps_last_device_state_when_refresh_fails(
     coordinator = ViClimateDataUpdateCoordinator(hass, mock_client)
     coordinator._known_devices = [known_device]
 
-    # Act: Refresh the coordinator with the failing device update.
+    # Act and Assert: Treat the failed poll as an unavailable coordinator update.
+    with pytest.raises(UpdateFailed, match="Failed to update all devices"):
+        await coordinator._async_update_data()
+
+    # Assert: Keep the immutable device reference for a later recovery attempt.
+    assert coordinator._known_devices == [known_device]
+    assert not coordinator.is_device_available("gw-main_device-0")
+
+
+@pytest.mark.asyncio
+async def test_data_coordinator_marks_only_failed_device_unavailable(
+    hass: HomeAssistant, mock_client
+) -> None:
+    """Test partial refresh failures only make the affected device unavailable."""
+    # Arrange: Refresh one device and fail the second device with a transient error.
+    refreshed_device = _build_device(device_id="device-0", gateway_serial="gw-main")
+    failing_device = _build_device(device_id="device-1", gateway_serial="gw-backup")
+    mock_client.update_device = AsyncMock(
+        side_effect=[refreshed_device, ViConnectionError("device offline")]
+    )
+    coordinator = ViClimateDataUpdateCoordinator(hass, mock_client)
+    coordinator._known_devices = [refreshed_device, failing_device]
+    coordinator._failed_device_keys = {"gw-main_device-0"}
+
+    # Act: Refresh the coordinator with one successful and one failed device poll.
     result = await coordinator._async_update_data()
 
-    # Assert: The previous device object stays available in coordinator data.
-    assert result == {"gw-main_device-0": known_device}
-    assert coordinator._known_devices == [known_device]
+    # Assert: Preserve the failed device for recovery while exposing its outage.
+    assert result == {
+        "gw-main_device-0": refreshed_device,
+        "gw-backup_device-1": failing_device,
+    }
+    assert coordinator.is_device_available("gw-main_device-0")
+    assert not coordinator.is_device_available("gw-backup_device-1")
 
 
 @pytest.mark.asyncio

--- a/tests/test_entity.py
+++ b/tests/test_entity.py
@@ -1,0 +1,54 @@
+"""Tests for shared Viessmann entity behavior."""
+
+from homeassistant.components.sensor import SensorEntityDescription
+from homeassistant.core import HomeAssistant
+from vi_api_client import Device, Feature
+
+from custom_components.vi_climate_devices.coordinator import (
+    ViClimateDataUpdateCoordinator,
+)
+from custom_components.vi_climate_devices.sensor import ViClimateSensor
+
+
+def _build_device() -> Device:
+    """Create a minimal device with one enabled sensor feature."""
+    return Device(
+        id="device-0",
+        gateway_serial="gw-main",
+        installation_id="installation-1",
+        model_id="Vitocal250A",
+        device_type="heating",
+        status="online",
+        features=[
+            Feature(
+                name="heating.sensors.temperature.outside",
+                value=12.2,
+                unit="celsius",
+                is_enabled=True,
+                is_ready=True,
+            )
+        ],
+    )
+
+
+def test_entity_is_unavailable_when_its_device_refresh_fails(
+    hass: HomeAssistant, mock_client
+) -> None:
+    """Test sensor availability follows the coordinator's per-device status."""
+    # Arrange: Create an enabled sensor for a successfully refreshed device.
+    device = _build_device()
+    device_key = "gw-main_device-0"
+    coordinator = ViClimateDataUpdateCoordinator(hass, mock_client)
+    coordinator.data = {device_key: device}
+    entity = ViClimateSensor(
+        coordinator,
+        device_key,
+        "heating.sensors.temperature.outside",
+        SensorEntityDescription(key="outside_temperature"),
+    )
+
+    # Act: Mark only this device as failed during a partial coordinator refresh.
+    coordinator._failed_device_keys.add(device_key)
+
+    # Assert: The entity is unavailable despite the coordinator having partial data.
+    assert not entity.available


### PR DESCRIPTION
## What changed

- Mark individual devices unavailable when their refresh fails while other devices refresh successfully.
- Raise `UpdateFailed` when every known device refresh fails.
- Add a shared coordinator-backed entity availability implementation and regression coverage for failed and recovered device updates.

## Why

- Previously, failed polls retained old device data and were reported as successful, so Home Assistant presented stale readings as current indefinitely.

## Impact

- A device with a failed poll is unavailable until a later refresh succeeds. Other devices in the same integration remain available.
- If all device polls fail, Home Assistant marks the coordinator update unavailable and retries normally.

## Validation

- `ruff format .`
- `ruff check --fix custom_components/vi_climate_devices tests`
- `pytest tests/` — 76 passed, 1 snapshot passed.
- Manifest JSON validation.