### PR TITLE
Serialize writes per device

### DIFF
--- a/custom_components/vi_climate_devices/climate.py
+++ b/custom_components/vi_climate_devices/climate.py
@@ -520,17 +520,13 @@ class ViClimate(ViClimateEntity, ClimateEntity):
                 f"{program_name}"
             )
 
-        device = self.coordinator.data.get(self._map_key)
-        if not device:
-            raise HomeAssistantError("Device not found")
-
         # 1. OPTIMISTIC UPDATE
         self._optimistic_temp = value
         self.async_write_ha_state()
 
         try:
-            response, updated_device = await self.coordinator.client.set_feature(
-                device, temp_feature, value
+            response = await self.coordinator.async_set_feature(
+                self._map_key, temp_feature.name, value
             )
             _LOGGER.debug(
                 "Command response for setting temperature: success=%s, "
@@ -544,9 +540,6 @@ class ViClimate(ViClimateEntity, ClimateEntity):
                 raise HomeAssistantError(
                     f"Command rejected: {response.message or response.reason}"
                 )
-
-            # Store updated device in coordinator.
-            self.coordinator.data[self._map_key] = updated_device
 
             # Clear optimistic value.
             self._optimistic_temp = None
@@ -587,17 +580,13 @@ class ViClimate(ViClimateEntity, ClimateEntity):
             else:
                 raise HomeAssistantError(f"Unsupported HVAC mode: {hvac_mode}")
 
-        device = self.coordinator.data.get(self._map_key)
-        if not device:
-            raise HomeAssistantError("Device not found")
-
         # 1. OPTIMISTIC UPDATE
         self._optimistic_mode = hvac_mode
         self.async_write_ha_state()
 
         try:
-            response, updated_device = await self.coordinator.client.set_feature(
-                device, mode_feature, target_api_mode
+            response = await self.coordinator.async_set_feature(
+                self._map_key, mode_feature.name, target_api_mode
             )
             _LOGGER.debug(
                 "Command response for setting HVAC mode: success=%s, "
@@ -611,9 +600,6 @@ class ViClimate(ViClimateEntity, ClimateEntity):
                 raise HomeAssistantError(
                     f"Command rejected: {response.message or response.reason}"
                 )
-
-            # Store updated device in coordinator.
-            self.coordinator.data[self._map_key] = updated_device
 
             # Clear optimistic mode.
             self._optimistic_mode = None

--- a/custom_components/vi_climate_devices/coordinator.py
+++ b/custom_components/vi_climate_devices/coordinator.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import logging
 from datetime import timedelta
 
@@ -14,6 +15,7 @@ from vi_api_client import (
     ViClient as ViessmannClient,
     ViError,
 )
+from vi_api_client.models import CommandResponse
 from vi_api_client.utils import mask_pii
 
 from .const import DOMAIN, IGNORED_DEVICES
@@ -40,10 +42,32 @@ class ViClimateDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Device]]):
         self.client = client
         self._known_devices: list[Device] = []
         self._failed_device_keys: set[str] = set()
+        self._device_write_locks: dict[str, asyncio.Lock] = {}
 
     def is_device_available(self, device_key: str) -> bool:
         """Return whether the most recent refresh succeeded for a device."""
         return device_key not in self._failed_device_keys
+
+    async def async_set_feature(
+        self, device_key: str, feature_name: str, value: object
+    ) -> CommandResponse:
+        """Set a feature while serializing writes for the same device."""
+        write_lock = self._device_write_locks.setdefault(device_key, asyncio.Lock())
+        async with write_lock:
+            device = self.data.get(device_key)
+            if device is None:
+                raise ValueError(f"Device {device_key} not found in coordinator data")
+
+            feature = device.get_feature(feature_name)
+            if feature is None:
+                raise ValueError(f"Feature {feature_name} not found in device data")
+
+            response, updated_device = await self.client.set_feature(
+                device, feature, value
+            )
+            if response.success:
+                self.data[device_key] = updated_device
+            return response
 
     async def _perform_discovery(self) -> None:
         """Perform initial device discovery.

--- a/custom_components/vi_climate_devices/number.py
+++ b/custom_components/vi_climate_devices/number.py
@@ -349,10 +349,6 @@ class ViClimateNumber(ViClimateEntity, NumberEntity):
 
     async def async_set_native_value(self, value: float) -> None:
         """Update the current value."""
-        device = self.coordinator.data.get(self._map_key)
-        if not device:
-            raise HomeAssistantError("Device not found")
-
         feat = self.feature_data
         if not feat:
             raise HomeAssistantError("Feature not available")
@@ -368,8 +364,9 @@ class ViClimateNumber(ViClimateEntity, NumberEntity):
             if precision is not None:
                 value = round(value, precision)
 
-            client = self.coordinator.client
-            response, updated_device = await client.set_feature(device, feat, value)
+            response = await self.coordinator.async_set_feature(
+                self._map_key, feat.name, value
+            )
             _LOGGER.debug(
                 "Command response: success=%s, message=%s, reason=%s",
                 response.success,
@@ -382,10 +379,7 @@ class ViClimateNumber(ViClimateEntity, NumberEntity):
                     f"Command rejected: {response.message or response.reason}"
                 )
 
-            # 3. Store optimistically updated device in coordinator
-            self.coordinator.data[self._map_key] = updated_device
-
-            # 4. Clear optimistic value - let next poll pick up real value
+            # 3. Clear optimistic value - let next poll pick up real value
             self._optimistic_value = None
             self.async_write_ha_state()
         except Exception as err:

--- a/custom_components/vi_climate_devices/select.py
+++ b/custom_components/vi_climate_devices/select.py
@@ -240,10 +240,6 @@ class ViClimateSelect(ViClimateEntity, SelectEntity):
 
     async def async_select_option(self, option: str) -> None:
         """Change the selected option."""
-        device = self.coordinator.data.get(self._map_key)
-        if not device:
-            raise HomeAssistantError("Device not found")
-
         feat = self.feature_data
         if not feat:
             raise HomeAssistantError("Feature not available")
@@ -254,8 +250,9 @@ class ViClimateSelect(ViClimateEntity, SelectEntity):
 
         # 2. EXECUTE COMMAND
         try:
-            client = self.coordinator.client
-            response, updated_device = await client.set_feature(device, feat, option)
+            response = await self.coordinator.async_set_feature(
+                self._map_key, feat.name, option
+            )
             _LOGGER.debug(
                 "Command response: success=%s, message=%s, reason=%s",
                 response.success,
@@ -268,10 +265,7 @@ class ViClimateSelect(ViClimateEntity, SelectEntity):
                     f"Command rejected: {response.message or response.reason}"
                 )
 
-            # 3. Store optimistically updated device in coordinator
-            self.coordinator.data[self._map_key] = updated_device
-
-            # 4. Clear optimistic value
+            # 3. Clear optimistic value
             self._optimistic_option = None
             self.async_write_ha_state()
         except Exception as err:

--- a/custom_components/vi_climate_devices/switch.py
+++ b/custom_components/vi_climate_devices/switch.py
@@ -185,10 +185,6 @@ class ViClimateSwitch(ViClimateEntity, SwitchEntity):
 
     async def _async_set_state(self, target_state: bool) -> None:
         """Internal method to set the switch state."""
-        device = self.coordinator.data.get(self._map_key)
-        if not device:
-            raise HomeAssistantError("Device not found")
-
         feat = self.feature_data
         if not feat:
             raise HomeAssistantError("Feature not available")
@@ -199,9 +195,8 @@ class ViClimateSwitch(ViClimateEntity, SwitchEntity):
 
         # 2. EXECUTE COMMAND
         try:
-            client = self.coordinator.client
-            response, updated_device = await client.set_feature(
-                device, feat, target_state
+            response = await self.coordinator.async_set_feature(
+                self._map_key, feat.name, target_state
             )
             _LOGGER.debug(
                 "Command response: success=%s, message=%s, reason=%s",
@@ -215,10 +210,7 @@ class ViClimateSwitch(ViClimateEntity, SwitchEntity):
                     f"Command rejected: {response.message or response.reason}"
                 )
 
-            # 3. Store optimistically updated device in coordinator
-            self.coordinator.data[self._map_key] = updated_device
-
-            # 4. Clear optimistic state
+            # 3. Clear optimistic state
             self._optimistic_state = None
             self.async_write_ha_state()
         except Exception as err:

--- a/custom_components/vi_climate_devices/water_heater.py
+++ b/custom_components/vi_climate_devices/water_heater.py
@@ -237,17 +237,13 @@ class ViClimateWaterHeater(ViClimateEntity, WaterHeaterEntity):
         if not feat:
             raise HomeAssistantError("Target temperature feature not found")
 
-        device = self.coordinator.data.get(self._map_key)
-        if not device:
-            raise HomeAssistantError("Device not found")
-
         # 1. OPTIMISTIC UPDATE
         self._optimistic_temp = value
         self.async_write_ha_state()
 
         try:
-            response, updated_device = await self.coordinator.client.set_feature(
-                device, feat, value
+            response = await self.coordinator.async_set_feature(
+                self._map_key, feat.name, value
             )
             _LOGGER.debug(
                 "Command response: success=%s, message=%s, reason=%s",
@@ -260,9 +256,6 @@ class ViClimateWaterHeater(ViClimateEntity, WaterHeaterEntity):
                 raise HomeAssistantError(
                     f"Command rejected: {response.message or response.reason}"
                 )
-
-            # Store optimistically updated device in coordinator
-            self.coordinator.data[self._map_key] = updated_device
 
             # Clear optimistic value - let next poll pick up real value
             self._optimistic_temp = None
@@ -278,10 +271,6 @@ class ViClimateWaterHeater(ViClimateEntity, WaterHeaterEntity):
         feat = self._get_feature(FEATURE_MODE)
         if not feat:
             raise HomeAssistantError("Mode feature not found")
-
-        device = self.coordinator.data.get(self._map_key)
-        if not device:
-            raise HomeAssistantError("Device not found")
 
         # Get available API modes from device
         available_api_modes = self._get_available_api_modes(feat)
@@ -310,8 +299,8 @@ class ViClimateWaterHeater(ViClimateEntity, WaterHeaterEntity):
         self.async_write_ha_state()
 
         try:
-            response, updated_device = await self.coordinator.client.set_feature(
-                device, feat, viessmann_mode
+            response = await self.coordinator.async_set_feature(
+                self._map_key, feat.name, viessmann_mode
             )
             _LOGGER.debug(
                 "Command response: success=%s, message=%s, reason=%s",
@@ -324,9 +313,6 @@ class ViClimateWaterHeater(ViClimateEntity, WaterHeaterEntity):
                 raise HomeAssistantError(
                     f"Command rejected: {response.message or response.reason}"
                 )
-
-            # Store optimistically updated device in coordinator
-            self.coordinator.data[self._map_key] = updated_device
 
             # Clear optimistic mode - let next poll pick up real value
             self._optimistic_mode = None

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -1,5 +1,6 @@
-"""Tests for coordinator discovery and refresh behavior."""
+"""Tests for coordinator discovery, refresh, and writes."""
 
+import asyncio
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
@@ -12,6 +13,7 @@ from homeassistant.exceptions import (
 )
 from homeassistant.helpers.update_coordinator import UpdateFailed
 from vi_api_client import Device, Feature, ViAuthError, ViConnectionError
+from vi_api_client.models import CommandResponse
 
 from custom_components.vi_climate_devices.coordinator import (
     ViClimateDataUpdateCoordinator,
@@ -65,6 +67,34 @@ def _make_token_error() -> OAuth2TokenRequestError:
         message="Internal Server Error",
         headers=MagicMock(),
         domain="vi_climate_devices",
+    )
+
+
+def _build_curve_device(slope: float, shift: float) -> Device:
+    """Create a device exposing both heating-curve command parameters."""
+    return Device(
+        id="device-0",
+        gateway_serial="gw-main",
+        installation_id="installation-1",
+        model_id="Vitocal250A",
+        device_type="heating",
+        status="online",
+        features=[
+            Feature(
+                name="heating.circuits.0.heating.curve.shift",
+                value=shift,
+                unit="celsius",
+                is_enabled=True,
+                is_ready=True,
+            ),
+            Feature(
+                name="heating.circuits.0.heating.curve.slope",
+                value=slope,
+                unit="celsius",
+                is_enabled=True,
+                is_ready=True,
+            ),
+        ],
     )
 
 
@@ -210,3 +240,59 @@ async def test_data_coordinator_propagates_transient_oauth_error(
     with pytest.raises(OAuth2TokenRequestError) as raised_error:
         await coordinator._async_update_data()
     assert raised_error.value is token_error
+
+
+@pytest.mark.asyncio
+async def test_data_coordinator_serializes_writes_per_device(
+    hass: HomeAssistant, mock_client
+) -> None:
+    """Test a queued write resolves its feature from the previous write result."""
+    # Arrange: Queue a curve-shift write behind a blocked curve-slope write.
+    device_key = "gw-main_device-0"
+    initial_device = _build_curve_device(slope=0.7, shift=0.0)
+    slope_updated_device = _build_curve_device(slope=1.2, shift=0.0)
+    final_device = _build_curve_device(slope=1.2, shift=0.4)
+    first_write_started = asyncio.Event()
+    allow_first_write_to_finish = asyncio.Event()
+    calls: list[tuple[Device, Feature, object]] = []
+
+    async def mock_set_feature(
+        device: Device, feature: Feature, value: object
+    ) -> tuple[CommandResponse, Device]:
+        calls.append((device, feature, value))
+        if feature.name.endswith("slope"):
+            first_write_started.set()
+            await allow_first_write_to_finish.wait()
+            return CommandResponse(
+                success=True, message=None, reason=None
+            ), slope_updated_device
+        return CommandResponse(success=True, message=None, reason=None), final_device
+
+    mock_client.set_feature = AsyncMock(side_effect=mock_set_feature)
+    coordinator = ViClimateDataUpdateCoordinator(hass, mock_client)
+    coordinator.data = {device_key: initial_device}
+
+    # Act: Start two writes for command parameters sharing one device.
+    slope_write = asyncio.create_task(
+        coordinator.async_set_feature(
+            device_key,
+            "heating.circuits.0.heating.curve.slope",
+            1.2,
+        )
+    )
+    await first_write_started.wait()
+    shift_write = asyncio.create_task(
+        coordinator.async_set_feature(
+            device_key,
+            "heating.circuits.0.heating.curve.shift",
+            0.4,
+        )
+    )
+    await asyncio.sleep(0)
+    allow_first_write_to_finish.set()
+    await asyncio.gather(slope_write, shift_write)
+
+    # Assert: The queued write uses the device returned by the first command.
+    assert calls[1][0] is slope_updated_device
+    assert calls[1][1].value == 0.0
+    assert coordinator.data[device_key] is final_device


### PR DESCRIPTION
## What changed

- Added a coordinator-managed lock for feature writes per device.
- Routed Number, Select, Switch, Climate, and Water Heater commands through the serialized coordinator path.
- Updated the coordinator cache within the lock after successful commands.
- Added a regression test for concurrent heating-curve slope and shift writes.

## Why

- Multiple Home Assistant platforms can command the same Viessmann device concurrently. `PARALLEL_UPDATES` is platform-scoped and cannot protect commands crossing Number, Climate, Select, Switch, or Water Heater.
- The Viessmann client resolves dependent command parameters from the supplied device snapshot, so a queued command must use the latest successful command result.

## Impact

- Commands for the same device execute in order and no longer overwrite dependent parameters using stale snapshots.
- Commands for different devices remain independent.

## Validation

- `ruff format .`
- `ruff check --fix custom_components/vi_climate_devices tests`
- `pytest tests/` — 77 passed, 1 snapshot passed.
- Manifest JSON validation.