### PR TITLE
Notify entities after device writes

### DIFF
--- a/custom_components/vi_climate_devices/coordinator.py
+++ b/custom_components/vi_climate_devices/coordinator.py
@@ -66,7 +66,9 @@ class ViClimateDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Device]]):
                 device, feature, value
             )
             if response.success:
-                self.data[device_key] = updated_device
+                updated_data = dict(self.data)
+                updated_data[device_key] = updated_device
+                self.async_set_updated_data(updated_data)
             return response
 
     async def _perform_discovery(self) -> None:

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -296,3 +296,39 @@ async def test_data_coordinator_serializes_writes_per_device(
     assert calls[1][0] is slope_updated_device
     assert calls[1][1].value == 0.0
     assert coordinator.data[device_key] is final_device
+
+
+@pytest.mark.asyncio
+async def test_data_coordinator_notifies_entities_after_successful_write(
+    hass: HomeAssistant, mock_client
+) -> None:
+    """Test a successful write publishes the updated device to listeners."""
+    # Arrange: Register a listener for a device whose curve slope will change.
+    device_key = "gw-main_device-0"
+    initial_device = _build_curve_device(slope=0.7, shift=0.0)
+    updated_device = _build_curve_device(slope=1.2, shift=0.0)
+    mock_client.set_feature = AsyncMock(
+        return_value=(
+            CommandResponse(success=True, message=None, reason=None),
+            updated_device,
+        )
+    )
+    coordinator = ViClimateDataUpdateCoordinator(hass, mock_client)
+    coordinator.data = {device_key: initial_device}
+    listener_data: list[Device] = []
+    coordinator.async_add_listener(
+        lambda: listener_data.append(coordinator.data[device_key])
+    )
+
+    try:
+        # Act: Set the slope through the shared coordinator write path.
+        await coordinator.async_set_feature(
+            device_key,
+            "heating.circuits.0.heating.curve.slope",
+            1.2,
+        )
+
+        # Assert: Every coordinator entity receives the new immutable device object.
+        assert listener_data == [updated_device]
+    finally:
+        await coordinator.async_shutdown()


### PR DESCRIPTION
## What changed

- Publish a new coordinator data mapping with `async_set_updated_data()` after a successful device command.
- Added regression coverage that verifies coordinator listeners receive the updated immutable device.

## Why

- A successful command previously updated only the command path cache. Other entities backed by the same device retained stale Home Assistant states until the next scheduled poll.

## Impact

- Every entity for the affected device updates immediately after a successful command.
- The next scheduled refresh is rescheduled by the coordinator as intended.

## Validation

- `ruff format .`
- `ruff check --fix custom_components/vi_climate_devices tests`
- `pytest tests/` — 78 passed, 1 snapshot passed.
- Manifest JSON validation.