### PR TITLE
Handle discovery authentication failures

### DIFF
--- a/custom_components/vi_climate_devices/coordinator.py
+++ b/custom_components/vi_climate_devices/coordinator.py
@@ -82,11 +82,11 @@ class ViClimateDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Device]]):
         """
         _LOGGER.debug("Performing initial discovery...")
 
-        installations = await self.client.get_installations()
-        if not installations:
-            raise UpdateFailed("No installations found")
-
         try:
+            installations = await self.client.get_installations()
+            if not installations:
+                raise UpdateFailed("No installations found")
+
             # Fetch devices from ALL installations
             all_devices: list[Device] = []
             for installation in installations:

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -113,6 +113,20 @@ async def test_data_coordinator_raises_when_no_installations_exist(
 
 
 @pytest.mark.asyncio
+async def test_data_coordinator_raises_reauth_when_installation_lookup_loses_auth(
+    hass: HomeAssistant, mock_client
+) -> None:
+    """Test discovery triggers reauth when listing installations loses auth."""
+    # Arrange: Reject the initial installation lookup with an auth failure.
+    mock_client.get_installations = AsyncMock(side_effect=ViAuthError("token expired"))
+    coordinator = ViClimateDataUpdateCoordinator(hass, mock_client)
+
+    # Act and Assert: Convert the discovery auth failure into a reauth trigger.
+    with pytest.raises(ConfigEntryAuthFailed, match="token expired"):
+        await coordinator._async_update_data()
+
+
+@pytest.mark.asyncio
 async def test_data_coordinator_discovers_devices_and_filters_ignored_ids(
     hass: HomeAssistant, mock_client
 ) -> None:


### PR DESCRIPTION
## What changed

- Moved the installation lookup inside the coordinator discovery error handling.
- Added regression coverage for authentication failure while listing installations.

## Why

- An authentication failure before device discovery was previously treated as a generic setup retry instead of triggering Home Assistant reauthentication.

## Impact

- Expired or revoked credentials during the initial installation lookup now start the standard reauth flow immediately.

## Validation

- `ruff format .`
- `ruff check --fix custom_components/vi_climate_devices tests`
- `pytest tests/` — 79 passed, 1 snapshot passed.
- Manifest JSON validation.