### PR TITLE
Preserve number default availability

### DIFF
--- a/custom_components/vi_climate_devices/number.py
+++ b/custom_components/vi_climate_devices/number.py
@@ -257,7 +257,7 @@ class ViClimateNumber(ViClimateEntity, NumberEntity):
         feature_name: str,
         description: NumberEntityDescription,
         translation_placeholders: dict[str, str] | None = None,
-        enabled_default: bool = True,
+        enabled_default: bool | None = None,
     ) -> None:
         """Initialize the entity."""
         super().__init__(coordinator)
@@ -265,7 +265,8 @@ class ViClimateNumber(ViClimateEntity, NumberEntity):
         self._map_key = map_key
         self._feature_name = feature_name
         self._attr_translation_placeholders = translation_placeholders or {}
-        self._attr_entity_registry_enabled_default = enabled_default
+        if enabled_default is not None:
+            self._attr_entity_registry_enabled_default = enabled_default
         self._optimistic_value: float | None = None
 
         device = coordinator.data.get(map_key)

--- a/tests/snapshots/test_discovery_snapshot.ambr
+++ b/tests/snapshots/test_discovery_snapshot.ambr
@@ -365,21 +365,6 @@
     dict({
       'attributes': dict({
         'device_class': 'temperature_delta',
-        'friendly_name': 'Vitocal250A DHW Hysteresis',
-        'icon': 'mdi:thermometer-lines',
-        'max': 10.0,
-        'min': 1.0,
-        'mode': <NumberMode.BOX: 'box'>,
-        'step': 0.5,
-        'unit_of_measurement': <UnitOfTemperature.KELVIN: 'K'>,
-        'viessmann_feature_name': 'heating.dhw.temperature.hysteresis',
-      }),
-      'entity_id': 'number.vitocal250a_dhw_hysteresis',
-      'state': '5',
-    }),
-    dict({
-      'attributes': dict({
-        'device_class': 'temperature_delta',
         'friendly_name': 'Vitocal250A DHW Hysteresis Switch Off',
         'icon': 'mdi:thermometer-minus',
         'max': 2.5,

--- a/tests/test_number.py
+++ b/tests/test_number.py
@@ -11,6 +11,7 @@ from homeassistant.components.number.const import (
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers import entity_registry as er
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 from vi_api_client.models import CommandResponse
 
@@ -75,6 +76,12 @@ async def test_number_creation_and_services(hass: HomeAssistant, mock_client):
         entity = component.get_entity(entity_id)
         assert entity is not None
         assert entity.suggested_display_precision == 1
+
+        # Assert: The noisy DHW hysteresis control stays disabled by default.
+        registry = er.async_get(hass)
+        hysteresis_entry = registry.async_get("number.vitocal250a_dhw_hysteresis")
+        assert hysteresis_entry is not None
+        assert hysteresis_entry.disabled_by is er.RegistryEntryDisabler.INTEGRATION
 
         # Act: Set slope to 1.6.
         await hass.services.async_call(


### PR DESCRIPTION
## What changed

- Preserve an entity description’s default-enable setting unless an entity is explicitly given an override.
- Added registry coverage for the disabled-by-default DHW hysteresis number.
- Updated the discovery snapshot to remove that default-disabled entity from active states.

## Why

- The Number constructor unconditionally set `entity_registry_enabled_default=True`, overriding the DHW hysteresis description that intentionally disables the entity by default.

## Impact

- `number.vitocal250a_dhw_hysteresis` is no longer enabled automatically on new installations. Existing user choices are preserved by Home Assistant’s entity registry.

## Validation

- Snapshot update inspected: only the intended DHW hysteresis entity was removed.
- `ruff format .`
- `ruff check --fix custom_components/vi_climate_devices tests`
- `pytest tests/` — 79 passed, 1 snapshot passed.
- Manifest JSON validation.