### PR TITLE
fix: use UnitOfRatio for percentage sensors

### DIFF
--- a/custom_components/vi_climate_devices/sensor.py
+++ b/custom_components/vi_climate_devices/sensor.py
@@ -15,12 +15,12 @@ from homeassistant.components.sensor import (
 )
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
-    PERCENTAGE,
     EntityCategory,
     UnitOfElectricCurrent,
     UnitOfEnergy,
     UnitOfPower,
     UnitOfPressure,
+    UnitOfRatio,
     UnitOfTemperature,
 )
 from homeassistant.core import HomeAssistant
@@ -57,7 +57,7 @@ SENSOR_TEMPLATES = [
         "description": SensorEntityDescription(
             key="placeholder",
             translation_key="burner_modulation",
-            native_unit_of_measurement=PERCENTAGE,
+            native_unit_of_measurement=UnitOfRatio.PERCENTAGE,
             icon="mdi:fire",
             state_class=SensorStateClass.MEASUREMENT,
         ),
@@ -230,7 +230,7 @@ SENSOR_TEMPLATES = [
         "description": SensorEntityDescription(
             key="placeholder",
             translation_key="fan_speed",
-            native_unit_of_measurement=PERCENTAGE,
+            native_unit_of_measurement=UnitOfRatio.PERCENTAGE,
             icon="mdi:fan",
             state_class=SensorStateClass.MEASUREMENT,
             entity_category=EntityCategory.DIAGNOSTIC,
@@ -538,7 +538,7 @@ SENSOR_TYPES: dict[str, SensorEntityDescription] = {
     "heating.sensors.humidity.outside": SensorEntityDescription(
         key="heating.sensors.humidity.outside",
         translation_key="outside_humidity",
-        native_unit_of_measurement=PERCENTAGE,
+        native_unit_of_measurement=UnitOfRatio.PERCENTAGE,
         device_class=SensorDeviceClass.HUMIDITY,
         state_class=SensorStateClass.MEASUREMENT,
     ),
@@ -653,7 +653,7 @@ def _get_auto_discovery_description(feature) -> SensorEntityDescription:
             native_unit = UnitOfPressure.BAR
             state_class = SensorStateClass.MEASUREMENT
         case "percent":
-            native_unit = PERCENTAGE
+            native_unit = UnitOfRatio.PERCENTAGE
             state_class = SensorStateClass.MEASUREMENT
         case "kilowattHour":
             device_class = SensorDeviceClass.ENERGY

--- a/tests/snapshots/test_discovery_snapshot.ambr
+++ b/tests/snapshots/test_discovery_snapshot.ambr
@@ -503,7 +503,7 @@
       'attributes': dict({
         'friendly_name': 'Vitocal250A Boiler Pumps Internal Current',
         'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-        'unit_of_measurement': '%',
+        'unit_of_measurement': <UnitOfRatio.PERCENTAGE: '%'>,
         'viessmann_feature_name': 'heating.boiler.pumps.internal.current',
       }),
       'entity_id': 'sensor.vitocal250a_boiler_pumps_internal_current',
@@ -513,7 +513,7 @@
       'attributes': dict({
         'friendly_name': 'Vitocal250A Boiler Pumps Internal Target',
         'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-        'unit_of_measurement': '%',
+        'unit_of_measurement': <UnitOfRatio.PERCENTAGE: '%'>,
         'viessmann_feature_name': 'heating.boiler.pumps.internal.target',
       }),
       'entity_id': 'sensor.vitocal250a_boiler_pumps_internal_target',
@@ -939,7 +939,7 @@
         'friendly_name': 'Vitocal250A Fan 0 Speed',
         'icon': 'mdi:fan',
         'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-        'unit_of_measurement': '%',
+        'unit_of_measurement': <UnitOfRatio.PERCENTAGE: '%'>,
         'viessmann_feature_name': 'heating.primaryCircuit.fans.0.current',
       }),
       'entity_id': 'sensor.vitocal250a_fan_0_speed',
@@ -950,7 +950,7 @@
         'friendly_name': 'Vitocal250A Fan 1 Speed',
         'icon': 'mdi:fan',
         'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-        'unit_of_measurement': '%',
+        'unit_of_measurement': <UnitOfRatio.PERCENTAGE: '%'>,
         'viessmann_feature_name': 'heating.primaryCircuit.fans.1.current',
       }),
       'entity_id': 'sensor.vitocal250a_fan_1_speed',
@@ -1057,7 +1057,7 @@
       'attributes': dict({
         'friendly_name': 'Vitocal250A Internal Pump One Default Limit',
         'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-        'unit_of_measurement': '%',
+        'unit_of_measurement': <UnitOfRatio.PERCENTAGE: '%'>,
         'viessmann_feature_name': 'heating.configuration.internalPumpOne.defaultLimit',
       }),
       'entity_id': 'sensor.vitocal250a_internal_pump_one_default_limit',
@@ -1067,7 +1067,7 @@
       'attributes': dict({
         'friendly_name': 'Vitocal250A Internal Pump One Maximum Limit',
         'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-        'unit_of_measurement': '%',
+        'unit_of_measurement': <UnitOfRatio.PERCENTAGE: '%'>,
         'viessmann_feature_name': 'heating.configuration.internalPumpOne.maximumLimit',
       }),
       'entity_id': 'sensor.vitocal250a_internal_pump_one_maximum_limit',
@@ -1077,7 +1077,7 @@
       'attributes': dict({
         'friendly_name': 'Vitocal250A Internal Pump One Minimum Limit',
         'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-        'unit_of_measurement': '%',
+        'unit_of_measurement': <UnitOfRatio.PERCENTAGE: '%'>,
         'viessmann_feature_name': 'heating.configuration.internalPumpOne.minimumLimit',
       }),
       'entity_id': 'sensor.vitocal250a_internal_pump_one_minimum_limit',
@@ -1087,7 +1087,7 @@
       'attributes': dict({
         'friendly_name': 'Vitocal250A Internal Pump Two Default Limit',
         'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-        'unit_of_measurement': '%',
+        'unit_of_measurement': <UnitOfRatio.PERCENTAGE: '%'>,
         'viessmann_feature_name': 'heating.configuration.internalPumpTwo.defaultLimit',
       }),
       'entity_id': 'sensor.vitocal250a_internal_pump_two_default_limit',
@@ -1097,7 +1097,7 @@
       'attributes': dict({
         'friendly_name': 'Vitocal250A Internal Pump Two Maximum Limit',
         'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-        'unit_of_measurement': '%',
+        'unit_of_measurement': <UnitOfRatio.PERCENTAGE: '%'>,
         'viessmann_feature_name': 'heating.configuration.internalPumpTwo.maximumLimit',
       }),
       'entity_id': 'sensor.vitocal250a_internal_pump_two_maximum_limit',
@@ -1107,7 +1107,7 @@
       'attributes': dict({
         'friendly_name': 'Vitocal250A Internal Pump Two Minimum Limit',
         'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-        'unit_of_measurement': '%',
+        'unit_of_measurement': <UnitOfRatio.PERCENTAGE: '%'>,
         'viessmann_feature_name': 'heating.configuration.internalPumpTwo.minimumLimit',
       }),
       'entity_id': 'sensor.vitocal250a_internal_pump_two_minimum_limit',
@@ -1117,7 +1117,7 @@
       'attributes': dict({
         'friendly_name': 'Vitocal250A Internal Pumps Default Limit',
         'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-        'unit_of_measurement': '%',
+        'unit_of_measurement': <UnitOfRatio.PERCENTAGE: '%'>,
         'viessmann_feature_name': 'heating.configuration.internalPumps.defaultLimit',
       }),
       'entity_id': 'sensor.vitocal250a_internal_pumps_default_limit',
@@ -1127,7 +1127,7 @@
       'attributes': dict({
         'friendly_name': 'Vitocal250A Internal Pumps Maximum Limit',
         'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-        'unit_of_measurement': '%',
+        'unit_of_measurement': <UnitOfRatio.PERCENTAGE: '%'>,
         'viessmann_feature_name': 'heating.configuration.internalPumps.maximumLimit',
       }),
       'entity_id': 'sensor.vitocal250a_internal_pumps_maximum_limit',
@@ -1137,7 +1137,7 @@
       'attributes': dict({
         'friendly_name': 'Vitocal250A Internal Pumps Minimum Limit',
         'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-        'unit_of_measurement': '%',
+        'unit_of_measurement': <UnitOfRatio.PERCENTAGE: '%'>,
         'viessmann_feature_name': 'heating.configuration.internalPumps.minimumLimit',
       }),
       'entity_id': 'sensor.vitocal250a_internal_pumps_minimum_limit',
@@ -1281,7 +1281,7 @@
       'attributes': dict({
         'friendly_name': 'Vitocal250A Secondary Circuit Valves Four Three Way Current',
         'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-        'unit_of_measurement': '%',
+        'unit_of_measurement': <UnitOfRatio.PERCENTAGE: '%'>,
         'viessmann_feature_name': 'heating.secondaryCircuit.valves.fourThreeWay.current',
       }),
       'entity_id': 'sensor.vitocal250a_secondary_circuit_valves_four_three_way_current',
@@ -1291,7 +1291,7 @@
       'attributes': dict({
         'friendly_name': 'Vitocal250A Secondary Circuit Valves Four Three Way Target',
         'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-        'unit_of_measurement': '%',
+        'unit_of_measurement': <UnitOfRatio.PERCENTAGE: '%'>,
         'viessmann_feature_name': 'heating.secondaryCircuit.valves.fourThreeWay.target',
       }),
       'entity_id': 'sensor.vitocal250a_secondary_circuit_valves_four_three_way_target',


### PR DESCRIPTION
## What changed
- Replace the removed `homeassistant.const.PERCENTAGE` constant with `UnitOfRatio.PERCENTAGE`.
- Update the discovery snapshot for Home Assistant’s typed percentage unit.

## Why
Home Assistant deprecated `PERCENTAGE` in 2026.7. The typed ratio unit is the supported replacement.

## Validation
- `ruff check .`
- `ruff format --check .`
- `python -m pytest -q` (81 passed)