### PR TITLE
docs: correct default polling interval

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ All entities are grouped under their respective device and support German and En
 
 **Entities not updating**
 - Check if your Viessmann gateway is online
-- API rate limit is respected (default: 60s polling interval)
+- API rate limit is respected (default: 3-minute polling interval)
 
 **Missing entities**
 - Not all features are available on all device models


### PR DESCRIPTION
## What changed
- Correct the documented default polling interval from 60 seconds to three minutes.

## Why
The data coordinator uses `timedelta(minutes=3)` as its default refresh interval.

## Documentation check
- Checked README, AGENTS.md, `.agent/rules/`, and `.agent/workflows/` for related polling guidance; no other documentation needs updating.