### PR TITLE
fix: correct DHW mode translations

### DIFF
--- a/custom_components/vi_climate_devices/strings.json
+++ b/custom_components/vi_climate_devices/strings.json
@@ -145,8 +145,8 @@
                     "off": "Off",
                     "eco": "Eco",
                     "comfort": "Comfort",
-                    "efficient": "Comfort",
-                    "efficientWithMinComfort": "Eco",
+                    "efficient": "Eco",
+                    "efficientWithMinComfort": "Comfort",
                     "balanced": "Balanced",
                     "standby": "Standby",
                     "standard": "Standard"
@@ -351,8 +351,8 @@
                     "off": "Off",
                     "eco": "Eco",
                     "comfort": "Comfort",
-                    "efficient": "Comfort",
-                    "efficientWithMinComfort": "Eco",
+                    "efficient": "Eco",
+                    "efficientWithMinComfort": "Comfort",
                     "balanced": "Balanced",
                     "standby": "Standby",
                     "standard": "Standard"

--- a/custom_components/vi_climate_devices/translations/en.json
+++ b/custom_components/vi_climate_devices/translations/en.json
@@ -348,8 +348,8 @@
                     "off": "Off",
                     "eco": "Eco",
                     "comfort": "Comfort",
-                    "efficient": "Comfort",
-                    "efficientWithMinComfort": "Eco",
+                    "efficient": "Eco",
+                    "efficientWithMinComfort": "Comfort",
                     "balanced": "Balanced",
                     "standby": "Standby",
                     "standard": "Standard"

--- a/tests/test_translations.py
+++ b/tests/test_translations.py
@@ -134,3 +134,14 @@ def test_translation_keys_exist(platform, translations):
     assert not error_msg, (
         f"Missing translations for platform '{platform}':\n" + "\n".join(error_msg)
     )
+
+
+def test_dhw_mode_translations_match_api_modes(translations):
+    """Keep the English DHW mode labels aligned with their API semantics."""
+    for translation in (translations["strings"], translations["en"]):
+        for platform in ("select", "water_heater"):
+            states = translation["entity"][platform][
+                "dhw_mode" if platform == "select" else "dhw_water_heater"
+            ]["state"]
+            assert states["efficient"] == "Eco"
+            assert states["efficientWithMinComfort"] == "Comfort"


### PR DESCRIPTION
## What changed
- Correct the English labels for `efficient` and `efficientWithMinComfort` in the canonical strings and water-heater translation.
- Add regression coverage for the DHW mode labels.

## Why
The two Viessmann DHW modes were displayed with swapped Eco and Comfort labels.

## Validation
- JSON validation for changed translation files
- `ruff check .`
- `ruff format --check .`
- `python -m pytest -q` (85 passed)

## Documentation check
- Translation-only correction; no README or operational documentation update is needed.