### PR TITLE
revert: prevent duplicate OAuth accounts

### DIFF
--- a/custom_components/vi_climate_devices/config_flow.py
+++ b/custom_components/vi_climate_devices/config_flow.py
@@ -6,14 +6,11 @@ import logging
 from collections.abc import Mapping
 
 import voluptuous as vol
-from aiohttp import ClientError
 from homeassistant.config_entries import SOURCE_REAUTH, ConfigFlowResult
 from homeassistant.helpers import config_entry_oauth2_flow
-from vi_api_client.const import API_BASE_URL, DEFAULT_SCOPES
+from vi_api_client.const import DEFAULT_SCOPES
 
 from .const import DOMAIN
-
-USER_PROFILE_URL = f"{API_BASE_URL}/users/v1/users/me?sections=identity"
 
 
 class OAuth2FlowHandler(
@@ -64,63 +61,9 @@ class OAuth2FlowHandler(
         data: dict[str, object],
     ) -> ConfigFlowResult:
         """Create or update the config entry after OAuth authentication."""
-        try:
-            account_id = await self._async_get_account_id(data)
-        except ClientError, ValueError:
-            return self.async_abort(reason="account_lookup_failed")
-
-        existing_entry = await self.async_set_unique_id(account_id)
-
         if self.source == SOURCE_REAUTH:
-            reauth_entry = self._get_reauth_entry()
-            if reauth_entry.unique_id is None:
-                if existing_entry and existing_entry.entry_id != reauth_entry.entry_id:
-                    return self.async_abort(reason="already_configured")
-                self.hass.config_entries.async_update_entry(
-                    reauth_entry, unique_id=account_id
-                )
-            else:
-                self._abort_if_unique_id_mismatch(reason="wrong_account")
             return self.async_update_reload_and_abort(
-                reauth_entry,
+                self._get_reauth_entry(),
                 data_updates=data,
             )
-
-        self._abort_if_unique_id_configured()
         return await super().async_oauth_create_entry(data)
-
-    async def _async_get_account_id(self, data: dict[str, object]) -> str:
-        """Return the authenticated Viessmann account identifier."""
-        token = data.get("token")
-        if not isinstance(token, dict) or not isinstance(
-            token.get("access_token"), str
-        ):
-            raise ValueError("OAuth response did not include an access token")
-
-        response = await config_entry_oauth2_flow.async_oauth2_request(
-            self.hass, token, "GET", USER_PROFILE_URL
-        )
-        try:
-            response.raise_for_status()
-            profile = await response.json()
-        finally:
-            response.release()
-
-        if not isinstance(profile, Mapping):
-            raise ValueError("User profile response was not an object")
-
-        account = profile.get("data", profile)
-        if not isinstance(account, Mapping):
-            raise ValueError("User profile data was not an object")
-
-        identity = account.get("identity", account)
-        if not isinstance(identity, Mapping):
-            identity = account
-
-        for source in (identity, account):
-            for key in ("id", "userId"):
-                account_id = source.get(key)
-                if isinstance(account_id, str) and account_id:
-                    return account_id
-
-        raise ValueError("User profile did not include an account identifier")

--- a/custom_components/vi_climate_devices/strings.json
+++ b/custom_components/vi_climate_devices/strings.json
@@ -15,8 +15,6 @@
         },
         "abort": {
             "already_configured": "Account is already configured",
-            "account_lookup_failed": "Unable to identify the authenticated account",
-            "wrong_account": "Please re-authenticate with the originally configured account",
             "reauth_successful": "Re-authentication was successful"
         }
     },

--- a/custom_components/vi_climate_devices/translations/de.json
+++ b/custom_components/vi_climate_devices/translations/de.json
@@ -15,8 +15,6 @@
         },
         "abort": {
             "already_configured": "Konto ist bereits konfiguriert",
-            "account_lookup_failed": "Das angemeldete Konto konnte nicht bestimmt werden",
-            "wrong_account": "Bitte melde dich erneut mit dem ursprünglich konfigurierten Konto an",
             "reauth_successful": "Erneute Authentifizierung war erfolgreich"
         }
     },

--- a/custom_components/vi_climate_devices/translations/en.json
+++ b/custom_components/vi_climate_devices/translations/en.json
@@ -15,8 +15,6 @@
         },
         "abort": {
             "already_configured": "Account is already configured",
-            "account_lookup_failed": "Unable to identify the authenticated account",
-            "wrong_account": "Please re-authenticate with the originally configured account",
             "reauth_successful": "Re-authentication was successful"
         }
     },

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -1,7 +1,7 @@
 """Tests for the OAuth config flow wrapper."""
 
 from typing import Any
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import patch
 
 import pytest
 from homeassistant import config_entries
@@ -12,10 +12,7 @@ from pytest_homeassistant_custom_component.common import MockConfigEntry
 from vi_api_client.const import DEFAULT_SCOPES
 from yarl import URL
 
-from custom_components.vi_climate_devices.config_flow import (
-    USER_PROFILE_URL,
-    OAuth2FlowHandler,
-)
+from custom_components.vi_climate_devices.config_flow import OAuth2FlowHandler
 from custom_components.vi_climate_devices.const import DOMAIN
 
 
@@ -45,29 +42,6 @@ class FakeOAuthImplementation(config_entry_oauth2_flow.AbstractOAuth2Implementat
         return token
 
 
-async def _complete_user_oauth_flow(
-    hass: HomeAssistant, implementation: FakeOAuthImplementation
-) -> dict[str, Any]:
-    """Complete a user-initiated OAuth flow."""
-    with patch(
-        "homeassistant.helpers.config_entry_oauth2_flow.async_get_implementations",
-        return_value={implementation.domain: implementation},
-    ):
-        start_result = await hass.config_entries.flow.async_init(
-            DOMAIN,
-            context={"source": config_entries.SOURCE_USER},
-        )
-        await hass.config_entries.flow.async_configure(
-            start_result["flow_id"],
-            {"implementation": implementation.domain},
-        )
-        await hass.config_entries.flow.async_configure(
-            start_result["flow_id"],
-            user_input={"code": "authorization-code"},
-        )
-        return await hass.config_entries.flow.async_configure(start_result["flow_id"])
-
-
 @pytest.mark.asyncio
 async def test_flow_handler_exposes_viessmann_scope() -> None:
     """Test the flow handler appends the Viessmann OAuth scopes to the authorize URL."""
@@ -79,35 +53,6 @@ async def test_flow_handler_exposes_viessmann_scope() -> None:
 
     # Assert: The flow publishes the library-defined Viessmann scope string.
     assert authorize_data == {"scope": DEFAULT_SCOPES}
-
-
-@pytest.mark.asyncio
-async def test_flow_handler_uses_logged_in_user_identity(
-    hass: HomeAssistant,
-) -> None:
-    """Use the logged-in user identity as the account unique ID."""
-    response = MagicMock()
-    response.json = AsyncMock(return_value={"data": {"identity": {"id": "account-1"}}})
-    flow_handler = OAuth2FlowHandler()
-    flow_handler.hass = hass
-
-    with patch(
-        "homeassistant.helpers.config_entry_oauth2_flow.async_oauth2_request",
-        return_value=response,
-    ) as oauth_request:
-        account_id = await flow_handler._async_get_account_id(
-            {"token": {"access_token": "token"}}
-        )
-
-    assert account_id == "account-1"
-    oauth_request.assert_awaited_once_with(
-        hass,
-        {"access_token": "token"},
-        "GET",
-        USER_PROFILE_URL,
-    )
-    response.raise_for_status.assert_called_once()
-    response.release.assert_called_once()
 
 
 @pytest.mark.asyncio
@@ -167,16 +112,9 @@ async def test_reauth_flow_shows_confirm_form_and_redirects_to_oauth(
 
     implementation = FakeOAuthImplementation()
 
-    with (
-        patch(
-            "homeassistant.helpers.config_entry_oauth2_flow.async_get_implementations",
-            return_value={implementation.domain: implementation},
-        ),
-        patch.object(
-            OAuth2FlowHandler,
-            "_async_get_account_id",
-            return_value="account-1",
-        ),
+    with patch(
+        "homeassistant.helpers.config_entry_oauth2_flow.async_get_implementations",
+        return_value={implementation.domain: implementation},
     ):
         # Act: Start the reauth flow (triggered by ConfigEntryAuthFailed).
         reauth_result = await entry.start_reauth_flow(hass)
@@ -211,74 +149,4 @@ async def test_reauth_flow_shows_confirm_form_and_redirects_to_oauth(
     assert entry.data["auth_implementation"] == "fake-provider"
     assert entry.data["retained_setting"] == "keep-me"
     assert entry.data["token"]["access_token"] == "token"
-    assert entry.unique_id == "account-1"
     assert len(hass.config_entries.async_entries(DOMAIN)) == 1
-
-
-@pytest.mark.asyncio
-async def test_user_flow_prevents_duplicate_account_entries(
-    hass: HomeAssistant,
-) -> None:
-    """Abort a second user flow for an already configured account."""
-    implementation = FakeOAuthImplementation()
-
-    with patch.object(
-        OAuth2FlowHandler,
-        "_async_get_account_id",
-        return_value="account-1",
-    ):
-        creation_result = await _complete_user_oauth_flow(hass, implementation)
-        duplicate_result = await _complete_user_oauth_flow(hass, implementation)
-
-    assert creation_result.get("type") is FlowResultType.CREATE_ENTRY
-    assert creation_result.get("result").unique_id == "account-1"
-    assert duplicate_result.get("type") is FlowResultType.ABORT
-    assert duplicate_result.get("reason") == "already_configured"
-    assert len(hass.config_entries.async_entries(DOMAIN)) == 1
-
-
-@pytest.mark.asyncio
-async def test_reauth_rejects_a_different_account(hass: HomeAssistant) -> None:
-    """Do not replace an entry's token with another account's token."""
-    entry = MockConfigEntry(
-        domain=DOMAIN,
-        unique_id="account-1",
-        data={
-            "auth_implementation": "fake-provider",
-            "token": {
-                "access_token": "expired-token",
-                "expires_at": 0,
-                "refresh_token": "dead-refresh",
-                "token_type": "Bearer",
-            },
-        },
-    )
-    entry.add_to_hass(hass)
-    implementation = FakeOAuthImplementation()
-
-    with (
-        patch(
-            "homeassistant.helpers.config_entry_oauth2_flow.async_get_implementations",
-            return_value={implementation.domain: implementation},
-        ),
-        patch.object(
-            OAuth2FlowHandler,
-            "_async_get_account_id",
-            return_value="account-2",
-        ),
-    ):
-        reauth_result = await entry.start_reauth_flow(hass)
-        await hass.config_entries.flow.async_configure(
-            reauth_result["flow_id"], user_input={}
-        )
-        await hass.config_entries.flow.async_configure(
-            reauth_result["flow_id"],
-            user_input={"code": "fresh-code"},
-        )
-        creation_result = await hass.config_entries.flow.async_configure(
-            reauth_result["flow_id"]
-        )
-
-    assert creation_result.get("type") is FlowResultType.ABORT
-    assert creation_result.get("reason") == "wrong_account"
-    assert entry.data["token"]["access_token"] == "expired-token"


### PR DESCRIPTION
## What changed
- Revert PR #90 in full, including account lookup, config-entry unique-ID handling, translations, and regression tests.

## Why
The OAuth account identity design is being reconsidered. The Viessmann-specific user lookup belongs in `vi_api_client` before it is used by the Home Assistant config flow.

## Validation
- `ruff check .`
- `ruff format --check .`
- JSON validation for config-flow translations
- `python -m pytest -q` (82 passed)