### PR TITLE
chore: release v1.4.4

### DIFF
--- a/custom_components/vi_climate_devices/manifest.json
+++ b/custom_components/vi_climate_devices/manifest.json
@@ -15,5 +15,5 @@
   "requirements": [
     "vi_api_client @ git+https://github.com/ignazhabibi/vi_api_client.git@v1.3.3"
   ],
-  "version": "1.4.3"
+  "version": "1.4.4"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vi_climate_devices"
-version = "1.4.3"
+version = "1.4.4"
 description = "Viessmann Climate Devices Integration for Home Assistant"
 authors = [
   { name = "Michael", email = "notme@bieber-home.net" },


### PR DESCRIPTION
## Release v1.4.4

### Bug fixes
- Mark entities for failed device refreshes unavailable instead of publishing stale data.
- Serialize writes per device and notify sibling entities after successful writes.
- Handle authentication failures during initial discovery correctly.
- Respect default-disabled number entities and require writable DHW water-heater controls.
- Use the supported Home Assistant percentage unit and correct DHW mode labels.

### Other changes
- Correct the documented default polling interval to three minutes.

### Validation
- `ruff check .`
- `ruff format --check .`
- `python -m pytest -q` (82 passed)