### PR TITLE
Prevent refreshes from overwriting writes

### DIFF
--- a/custom_components/vi_climate_devices/coordinator.py
+++ b/custom_components/vi_climate_devices/coordinator.py
@@ -43,6 +43,7 @@ class ViClimateDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Device]]):
         self._known_devices: list[Device] = []
         self._failed_device_keys: set[str] = set()
         self._device_write_locks: dict[str, asyncio.Lock] = {}
+        self._refresh_write_lock = asyncio.Lock()
 
     def is_device_available(self, device_key: str) -> bool:
         """Return whether the most recent refresh succeeded for a device."""
@@ -52,24 +53,43 @@ class ViClimateDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Device]]):
         self, device_key: str, feature_name: str, value: object
     ) -> CommandResponse:
         """Set a feature while serializing writes for the same device."""
-        write_lock = self._device_write_locks.setdefault(device_key, asyncio.Lock())
-        async with write_lock:
-            device = self.data.get(device_key)
-            if device is None:
-                raise ValueError(f"Device {device_key} not found in coordinator data")
+        async with self._refresh_write_lock:
+            write_lock = self._device_write_locks.setdefault(device_key, asyncio.Lock())
+            async with write_lock:
+                device = self.data.get(device_key)
+                if device is None:
+                    raise ValueError(
+                        f"Device {device_key} not found in coordinator data"
+                    )
 
-            feature = device.get_feature(feature_name)
-            if feature is None:
-                raise ValueError(f"Feature {feature_name} not found in device data")
+                feature = device.get_feature(feature_name)
+                if feature is None:
+                    raise ValueError(f"Feature {feature_name} not found in device data")
 
-            response, updated_device = await self.client.set_feature(
-                device, feature, value
+                response, updated_device = await self.client.set_feature(
+                    device, feature, value
+                )
+                if response.success:
+                    updated_data = dict(self.data)
+                    updated_data[device_key] = updated_device
+                    self.async_set_updated_data(updated_data)
+                return response
+
+    async def _async_refresh(
+        self,
+        log_failures: bool = True,
+        raise_on_auth_failed: bool = False,
+        scheduled: bool = False,
+        raise_on_entry_error: bool = False,
+    ) -> None:
+        """Refresh data without racing successful writes."""
+        async with self._refresh_write_lock:
+            await super()._async_refresh(
+                log_failures=log_failures,
+                raise_on_auth_failed=raise_on_auth_failed,
+                scheduled=scheduled,
+                raise_on_entry_error=raise_on_entry_error,
             )
-            if response.success:
-                updated_data = dict(self.data)
-                updated_data[device_key] = updated_device
-                self.async_set_updated_data(updated_data)
-            return response
 
     async def _perform_discovery(self) -> None:
         """Perform initial device discovery.

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -313,6 +313,59 @@ async def test_data_coordinator_serializes_writes_per_device(
 
 
 @pytest.mark.asyncio
+async def test_data_coordinator_does_not_overwrite_a_write_with_stale_refresh(
+    hass: HomeAssistant, mock_client
+) -> None:
+    """Test a write waits for an in-progress refresh before updating coordinator data."""
+    # Arrange: Start a refresh whose response still contains the old curve slope.
+    device_key = "gw-main_device-0"
+    initial_device = _build_curve_device(slope=0.7, shift=0.0)
+    refreshed_device = _build_curve_device(slope=0.7, shift=0.0)
+    written_device = _build_curve_device(slope=1.2, shift=0.0)
+    refresh_started = asyncio.Event()
+    allow_refresh_to_finish = asyncio.Event()
+
+    async def mock_update_device(device: Device) -> Device:
+        refresh_started.set()
+        await allow_refresh_to_finish.wait()
+        return refreshed_device
+
+    mock_client.update_device = AsyncMock(side_effect=mock_update_device)
+    mock_client.set_feature = AsyncMock(
+        return_value=(
+            CommandResponse(success=True, message=None, reason=None),
+            written_device,
+        )
+    )
+    coordinator = ViClimateDataUpdateCoordinator(hass, mock_client)
+    coordinator.data = {device_key: initial_device}
+    coordinator._known_devices = [initial_device]
+
+    # Act: Begin a refresh, then write a new slope before its stale response returns.
+    refresh_task = asyncio.create_task(coordinator.async_refresh())
+    await refresh_started.wait()
+    write_task = asyncio.create_task(
+        coordinator.async_set_feature(
+            device_key,
+            "heating.circuits.0.heating.curve.slope",
+            1.2,
+        )
+    )
+    await asyncio.sleep(0)
+    assert mock_client.set_feature.call_count == 0
+    allow_refresh_to_finish.set()
+    await asyncio.gather(refresh_task, write_task)
+
+    # Assert: The completed write remains the coordinator's current device data.
+    assert (
+        coordinator.data[device_key]
+        .get_feature("heating.circuits.0.heating.curve.slope")
+        .value
+        == 1.2
+    )
+
+
+@pytest.mark.asyncio
 async def test_data_coordinator_notifies_entities_after_successful_write(
     hass: HomeAssistant, mock_client
 ) -> None:


### PR DESCRIPTION
What changed
- Serialize coordinator refreshes and feature writes until their state updates are published.
- Add regression coverage for a stale refresh racing a successful write.

Why
A refresh that began before a write could previously replace its successful result with stale device data.

Impact
Subsequent combined Viessmann commands use the most recently confirmed feature values.

Validation
- ruff check on changed files
- ruff format --check .
- python -m pytest -q (83 passed)
- manifest JSON validation

Note: ruff check . remains red on four pre-existing unused noqa directives outside this PR.