### PR TITLE
Enable climate turn actions

### DIFF
--- a/custom_components/vi_climate_devices/climate.py
+++ b/custom_components/vi_climate_devices/climate.py
@@ -146,6 +146,20 @@ class ViClimate(ViClimateEntity, ClimateEntity):
         self._attr_has_entity_name = True
         self._attr_translation_placeholders = {"index": circuit_index}
 
+        mode_feature = self._get_feature(
+            f"heating.circuits.{self._circuit_index}.operating.modes.active"
+        )
+        available_hvac_modes = self.hvac_modes
+        if (
+            mode_feature
+            and mode_feature.is_writable
+            and HVACMode.OFF in available_hvac_modes
+            and any(mode != HVACMode.OFF for mode in available_hvac_modes)
+        ):
+            self._attr_supported_features |= (
+                ClimateEntityFeature.TURN_ON | ClimateEntityFeature.TURN_OFF
+            )
+
     @property
     def device_info(self) -> DeviceInfo | None:
         """Return device information."""

--- a/tests/snapshots/test_discovery_snapshot.ambr
+++ b/tests/snapshots/test_discovery_snapshot.ambr
@@ -310,7 +310,7 @@
         ]),
         'max_temp': 37.0,
         'min_temp': 3.0,
-        'supported_features': <ClimateEntityFeature: 1>,
+        'supported_features': <ClimateEntityFeature: 385>,
         'target_temp_step': 1.0,
         'temperature': 20.0,
       }),

--- a/tests/test_climate.py
+++ b/tests/test_climate.py
@@ -14,6 +14,7 @@ from homeassistant.components.climate.const import (
     HVACAction,
     HVACMode,
 )
+from homeassistant.const import SERVICE_TURN_OFF, SERVICE_TURN_ON
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from pytest_homeassistant_custom_component.common import MockConfigEntry
@@ -242,7 +243,9 @@ async def test_hvac_action(
 
 
 @pytest.mark.asyncio
-async def test_climate_creation_and_services(hass: HomeAssistant, mock_client) -> None:
+async def test_climate_creation_and_services(  # noqa: PLR0915
+    hass: HomeAssistant, mock_client
+) -> None:
     """Test climate entity creation, attributes, and service calls."""
     # Arrange: Mock Config Entry and setup integration.
     entry = MockConfigEntry(
@@ -353,6 +356,24 @@ async def test_climate_creation_and_services(hass: HomeAssistant, mock_client) -
         args, _ = mock_client.set_feature.call_args
         assert args[1].name == "heating.circuits.0.operating.modes.active"
         assert args[2] == "heating"
+
+        # Act: Use the supported Climate turn actions.
+        mock_client.set_feature.reset_mock()
+        await hass.services.async_call(
+            "climate", SERVICE_TURN_ON, {"entity_id": entity_id}, blocking=True
+        )
+        await hass.services.async_call(
+            "climate", SERVICE_TURN_OFF, {"entity_id": entity_id}, blocking=True
+        )
+
+        # Assert: The actions change the operating mode instead of being rejected.
+        assert mock_client.set_feature.call_count == 2
+        args, _ = mock_client.set_feature.call_args_list[0]
+        assert args[1].name == "heating.circuits.0.operating.modes.active"
+        assert args[2] == "heating"
+        args, _ = mock_client.set_feature.call_args_list[1]
+        assert args[1].name == "heating.circuits.0.operating.modes.active"
+        assert args[2] == "standby"
 
         # Act & Assert: Attempting to set preset mode raises HomeAssistantError since it is not supported.
         with pytest.raises(


### PR DESCRIPTION
What changed
- Advertise climate turn_on and turn_off only for writable circuits that support off and an active HVAC mode.
- Add integration coverage for both Climate actions.
- Update the discovery snapshot for the published feature flags.

Why
Home Assistant rejected climate.turn_on and climate.turn_off even though the integration could set the corresponding HVAC modes.

Impact
Climate automations and dashboard actions can now turn supported heating circuits on and off.

Validation
- ruff check on changed files
- ruff format --check .
- python -m pytest -q (84 passed)
- manifest JSON validation

Note: ruff check . remains red on four pre-existing unused noqa directives outside this PR.