### PR TITLE
Release v1.4.5

### DIFF
--- a/custom_components/vi_climate_devices/manifest.json
+++ b/custom_components/vi_climate_devices/manifest.json
@@ -15,5 +15,5 @@
   "requirements": [
     "vi_api_client @ git+https://github.com/ignazhabibi/vi_api_client.git@v1.3.3"
   ],
-  "version": "1.4.4"
+  "version": "1.4.5"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vi_climate_devices"
-version = "1.4.4"
+version = "1.4.5"
 description = "Viessmann Climate Devices Integration for Home Assistant"
 authors = [
   { name = "Michael", email = "notme@bieber-home.net" },


### PR DESCRIPTION
## What changed

- Prevent an in-flight coordinator refresh from overwriting a successful device command.
- Apply a requested HVAC mode when changing the climate target temperature.
- Expose heating-curve shifts as temperature differences.
- Enable the standard climate turn-on and turn-off actions.
- Map a DHW-only heating-circuit mode to `off`.

## Why

These five fixes correct device state handling and Home Assistant climate-service behavior released since v1.4.4.

## Impact

Patch release with bug fixes only; no configuration migration is required.

## Validation

- `ruff check --ignore RUF100 .`
- `ruff format --check .`
- `.venv/bin/python -m pytest -q` — 85 passed
- Fresh Python 3.14 environment installed with `.[dev]`, then `pytest -q` — 85 passed
