### PR TITLE
chore: add pyright quality check

### DIFF
--- a/.agent/rules/git-workflow.md
+++ b/.agent/rules/git-workflow.md
@@ -24,7 +24,8 @@ Strict guidelines for version control and feature development.
 ### B. Develop (The Loop)
 1. Write code (`src/` and `tests/`).
 2. **Local Tests**: Run `python -m pytest -q` frequently.
-3. **Local Lint**: Run `ruff check .` and `ruff format --check .` before every commit.
+3. **Local Quality Checks**: Run `ruff check .`, `ruff format --check .`, and
+   `pyright --pythonpath .venv/bin/python` before every commit.
 4. **Commit**: `git commit -m "type: description"` (Conventional Commits).
    - Preferred format in this repository is `type: description`.
    - Use `feat`, `fix`, `refactor`, `docs`, `test`, or `chore`.
@@ -58,4 +59,6 @@ Strict guidelines for version control and feature development.
 - **Allowed**: `git checkout -b`, `git add`, `git commit`, `git push`.
 - **Forbidden**: `git merge` (User does this via UI), committing to `main`
   outside an explicitly approved emergency bypass.
-- **Validation**: The Agent must run `ruff check .`, `ruff format --check .`, and `python -m pytest -q` before proposing a push.
+- **Validation**: The Agent must run `ruff check .`, `ruff format --check .`,
+  `pyright --pythonpath .venv/bin/python`, and `python -m pytest -q` before
+  proposing a push.

--- a/.agent/rules/tech-stack.md
+++ b/.agent/rules/tech-stack.md
@@ -13,13 +13,19 @@ trigger: always_on
 - **Generics:** Use built-in generics (e.g., `list[str]` instead of `List[str]`).
 - **Self:** Do not annotate `self` in methods.
 
-## 3. Error Handling & Logic
+## 3. Static Type Checking
+- Use Pyright with the shared configuration in `pyproject.toml`.
+- Run `pyright --pythonpath .venv/bin/python` locally. The CI workflow passes
+  its active interpreter explicitly.
+- Keep the Pylance type-checking mode aligned with Pyright's configured mode.
+
+## 4. Error Handling & Logic
 - **Specific Exceptions:** NEVER catch a bare `Exception`. Catch specific errors (e.g., `ValueError`, `FileNotFoundError`).
 - **EAFP:** Prefer "Easier to Ask for Forgiveness than Permission" (try/except) over extensive `if` checks where Pythonic.
 - **Custom Exceptions:** Define custom exceptions in `exceptions.py`.
 - **No Leaking:** Do not raise HTTP-specific exceptions (like `HTTPException`) in the service/library layer. Keep the core logic clean.
 
-## 4. Filesystem
+## 5. Filesystem
 - **Pathlib:** Always use `pathlib.Path`.
     - ❌ Wrong: `os.path.join(a, b)`
     - ✅ Right: `pathlib.Path(a) / b`

--- a/.agent/workflows/feature-develop.md
+++ b/.agent/workflows/feature-develop.md
@@ -57,6 +57,11 @@ ruff format --check .
 
 // turbo
 ```bash
+pyright --pythonpath .venv/bin/python
+```
+
+// turbo
+```bash
 python -m pytest -q
 ```
 

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -28,6 +28,8 @@ jobs:
       run: |
         ruff check .
         ruff format --check .
+    - name: Type check (Pyright)
+      run: pyright --pythonpath "$(which python)"
     - name: Tests
       run: python -m pytest -q
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,6 +29,8 @@ jobs:
       run: |
         ruff check .
         ruff format --check .
+    - name: Type check (Pyright)
+      run: pyright --pythonpath "$(which python)"
     - name: Tests
       run: python -m pytest -q
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -106,6 +106,7 @@ Primary local quality gates:
 ```bash
 ruff check .
 ruff format --check .
+pyright --pythonpath .venv/bin/python
 python -m pytest -q
 ```
 
@@ -114,7 +115,7 @@ validate once in a fresh environment installed with `.[dev]`.
 
 ## CI and Release Notes
 
-- CI currently runs via `.github/workflows/release.yml` for `main`, pull
+- CI currently runs Ruff, Pyright, and pytest via `.github/workflows/release.yml` for `main`, pull
   requests, and stable release tags, plus `.github/workflows/pre-release.yml`
   for prerelease tags.
 - `main` is protected by a GitHub ruleset. Assume pull requests are required for

--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ python3.14 -m venv .venv
 source .venv/bin/activate
 python -m pip install --upgrade pip
 python -m pip install '.[dev]'
+pyright --pythonpath .venv/bin/python
 python -m pytest -q
 ```
 
@@ -143,6 +144,7 @@ python -m pytest -q
 ```bash
 ruff check .
 ruff format --check .
+pyright --pythonpath .venv/bin/python
 ```
 
 ---

--- a/custom_components/vi_climate_devices/__init__.py
+++ b/custom_components/vi_climate_devices/__init__.py
@@ -5,13 +5,14 @@ from __future__ import annotations
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
-from homeassistant.helpers import config_entry_oauth2_flow
-from homeassistant.helpers.aiohttp_client import async_get_clientsession
-from homeassistant.helpers.config_entry_oauth2_flow import (
+from homeassistant.exceptions import (
+    ConfigEntryAuthFailed,
+    ConfigEntryNotReady,
     OAuth2TokenRequestError,
     OAuth2TokenRequestReauthError,
 )
+from homeassistant.helpers import config_entry_oauth2_flow
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from vi_api_client import ViClient as ViessmannClient
 from vi_api_client.auth import AbstractAuth
 

--- a/custom_components/vi_climate_devices/climate.py
+++ b/custom_components/vi_climate_devices/climate.py
@@ -5,12 +5,7 @@ from __future__ import annotations
 import logging
 from typing import Any
 
-from homeassistant.components.climate import (
-    ClimateEntity,
-    ClimateEntityFeature,
-    HVACAction,
-    HVACMode,
-)
+from homeassistant.components.climate import ClimateEntity
 from homeassistant.components.climate.const import (
     ATTR_HVAC_MODE,
     PRESET_AWAY,
@@ -18,6 +13,9 @@ from homeassistant.components.climate.const import (
     PRESET_ECO,
     PRESET_HOME,
     PRESET_SLEEP,
+    ClimateEntityFeature,
+    HVACAction,
+    HVACMode,
 )
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import ATTR_TEMPERATURE, UnitOfTemperature

--- a/custom_components/vi_climate_devices/entity.py
+++ b/custom_components/vi_climate_devices/entity.py
@@ -10,6 +10,8 @@ from .coordinator import ViClimateDataUpdateCoordinator
 class ViClimateEntity(CoordinatorEntity[ViClimateDataUpdateCoordinator]):
     """Base entity that reflects per-device refresh availability."""
 
+    _map_key: str
+
     @property
     def available(self) -> bool:
         """Return whether the coordinator has current data for this device."""

--- a/custom_components/vi_climate_devices/water_heater.py
+++ b/custom_components/vi_climate_devices/water_heater.py
@@ -9,13 +9,12 @@ from homeassistant.components.water_heater import (
     STATE_ECO,
     STATE_GAS,
     STATE_HEAT_PUMP,
-    STATE_OFF,
     STATE_PERFORMANCE,
     WaterHeaterEntity,
     WaterHeaterEntityFeature,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import ATTR_TEMPERATURE, UnitOfTemperature
+from homeassistant.const import ATTR_TEMPERATURE, STATE_OFF, UnitOfTemperature
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.device_registry import DeviceInfo

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,9 +21,21 @@ dependencies = [
 
 [project.optional-dependencies]
 dev = [
+    "pyright==1.1.411",
     "pytest-homeassistant-custom-component==0.13.363",
     "ruff==0.16.6",
 ]
+
+[tool.pyright]
+include = ["custom_components", "tests"]
+exclude = [".venv", "build", "dist"]
+pythonVersion = "3.14"
+extraPaths = []
+typeCheckingMode = "standard"
+# Home Assistant declares cached properties in base classes, while integrations
+# may validly override them with properties.
+reportIncompatibleVariableOverride = "none"
+
 [tool.ruff]
 line-length = 88
 target-version = "py314"

--- a/tests/test_climate.py
+++ b/tests/test_climate.py
@@ -339,7 +339,9 @@ async def test_climate_creation_and_services(  # noqa: PLR0915
         args, _ = mock_client.set_feature.call_args_list[1]
         assert args[1].name == "heating.circuits.0.operating.modes.active"
         assert args[2] == "standby"
-        assert hass.states.get(entity_id).state == HVACMode.OFF
+        state = hass.states.get(entity_id)
+        assert state is not None
+        assert state.state == HVACMode.OFF
 
         # Reset Mock.
         mock_client.set_feature.reset_mock()

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -357,12 +357,11 @@ async def test_data_coordinator_does_not_overwrite_a_write_with_stale_refresh(
     await asyncio.gather(refresh_task, write_task)
 
     # Assert: The completed write remains the coordinator's current device data.
-    assert (
-        coordinator.data[device_key]
-        .get_feature("heating.circuits.0.heating.curve.slope")
-        .value
-        == 1.2
+    updated_feature = coordinator.data[device_key].get_feature(
+        "heating.circuits.0.heating.curve.slope"
     )
+    assert updated_feature is not None
+    assert updated_feature.value == 1.2
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- add a shared Pyright standard-mode configuration and development dependency
- run Pyright in release and prerelease CI workflows
- correct type-check findings and document the local quality gate

## Verification
- pyright --pythonpath /tmp/vi-climate-pyright-verify/bin/python
- ruff check .
- ruff format --check .
- python -m pytest -q (85 passed)