### PR TITLE
chore: add pre-commit quality gate

### DIFF
--- a/.agent/rules/git-workflow.md
+++ b/.agent/rules/git-workflow.md
@@ -24,8 +24,8 @@ Strict guidelines for version control and feature development.
 ### B. Develop (The Loop)
 1. Write code (`src/` and `tests/`).
 2. **Local Tests**: Run `python -m pytest -q` frequently.
-3. **Local Quality Checks**: Run `ruff check .`, `ruff format --check .`, and
-   `pyright --pythonpath .venv/bin/python` before every commit.
+3. **Local Quality Check**: Run `python scripts/quality_check.py` before every
+   commit. The installed pre-commit hook repeats this automatically.
 4. **Commit**: `git commit -m "type: description"` (Conventional Commits).
    - Preferred format in this repository is `type: description`.
    - Use `feat`, `fix`, `refactor`, `docs`, `test`, or `chore`.
@@ -59,6 +59,5 @@ Strict guidelines for version control and feature development.
 - **Allowed**: `git checkout -b`, `git add`, `git commit`, `git push`.
 - **Forbidden**: `git merge` (User does this via UI), committing to `main`
   outside an explicitly approved emergency bypass.
-- **Validation**: The Agent must run `ruff check .`, `ruff format --check .`,
-  `pyright --pythonpath .venv/bin/python`, and `python -m pytest -q` before
+- **Validation**: The Agent must run `python scripts/quality_check.py` before
   proposing a push.

--- a/.agent/rules/tech-stack.md
+++ b/.agent/rules/tech-stack.md
@@ -19,13 +19,18 @@ trigger: always_on
   its active interpreter explicitly.
 - Keep the Pylance type-checking mode aligned with Pyright's configured mode.
 
-## 4. Error Handling & Logic
+## 4. Quality Gate
+- Run `python scripts/quality_check.py` for the complete local gate.
+- Install the versioned pre-commit hook after the development dependencies.
+- The hook and CI both use the same quality-check script.
+
+## 5. Error Handling & Logic
 - **Specific Exceptions:** NEVER catch a bare `Exception`. Catch specific errors (e.g., `ValueError`, `FileNotFoundError`).
 - **EAFP:** Prefer "Easier to Ask for Forgiveness than Permission" (try/except) over extensive `if` checks where Pythonic.
 - **Custom Exceptions:** Define custom exceptions in `exceptions.py`.
 - **No Leaking:** Do not raise HTTP-specific exceptions (like `HTTPException`) in the service/library layer. Keep the core logic clean.
 
-## 5. Filesystem
+## 6. Filesystem
 - **Pathlib:** Always use `pathlib.Path`.
     - ❌ Wrong: `os.path.join(a, b)`
     - ✅ Right: `pathlib.Path(a) / b`

--- a/.agent/workflows/feature-develop.md
+++ b/.agent/workflows/feature-develop.md
@@ -45,24 +45,8 @@ Iterate on your feature with frequent validation.
 ### B. Validate Locally
 Before each commit:
 
-// turbo
 ```bash
-ruff check .
-```
-
-// turbo
-```bash
-ruff format --check .
-```
-
-// turbo
-```bash
-pyright --pythonpath .venv/bin/python
-```
-
-// turbo
-```bash
-python -m pytest -q
+python scripts/quality_check.py
 ```
 
 When changing test dependencies, CI config, packaging metadata, or snapshot

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -24,14 +24,8 @@ jobs:
         python -m pip install --upgrade pip
         python -m pip install build
         python -m pip install '.[dev]'
-    - name: Lint & Format (Ruff)
-      run: |
-        ruff check .
-        ruff format --check .
-    - name: Type check (Pyright)
-      run: pyright --pythonpath "$(which python)"
-    - name: Tests
-      run: python -m pytest -q
+    - name: Quality check
+      run: python scripts/quality_check.py
 
   pre-release:
     needs: quality-check

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,14 +25,8 @@ jobs:
         python -m pip install --upgrade pip
         python -m pip install build
         python -m pip install '.[dev]'
-    - name: Lint & Format (Ruff)
-      run: |
-        ruff check .
-        ruff format --check .
-    - name: Type check (Pyright)
-      run: pyright --pythonpath "$(which python)"
-    - name: Tests
-      run: python -m pytest -q
+    - name: Quality check
+      run: python scripts/quality_check.py
 
   release:
     needs: quality-check

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,11 @@
+minimum_pre_commit_version: "4.6.2"
+
+repos:
+  - repo: local
+    hooks:
+      - id: quality-check
+        name: Quality check
+        entry: .venv/bin/python scripts/quality_check.py
+        language: system
+        pass_filenames: false
+        always_run: true

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -104,10 +104,7 @@ python -m pip install '.[dev]'
 Primary local quality gates:
 
 ```bash
-ruff check .
-ruff format --check .
-pyright --pythonpath .venv/bin/python
-python -m pytest -q
+python scripts/quality_check.py
 ```
 
 If a change touches snapshots, test dependencies, CI config, or packaging,
@@ -115,7 +112,7 @@ validate once in a fresh environment installed with `.[dev]`.
 
 ## CI and Release Notes
 
-- CI currently runs Ruff, Pyright, and pytest via `.github/workflows/release.yml` for `main`, pull
+- CI currently runs `scripts/quality_check.py` via `.github/workflows/release.yml` for `main`, pull
   requests, and stable release tags, plus `.github/workflows/pre-release.yml`
   for prerelease tags.
 - `main` is protected by a GitHub ruleset. Assume pull requests are required for
@@ -123,6 +120,8 @@ validate once in a fresh environment installed with `.[dev]`.
   the user explicitly asks for a confirmed emergency bypass.
 - Python support baseline is 3.14+ across packaging, CI, and repository guidance.
 - Prefer matching the current CI Python version locally for verification.
+- Run `pre-commit install --install-hooks` after installing `.[dev]`. The
+  installed hook runs the complete quality check before each normal commit.
 - Home Assistant release versioning is driven by
   `custom_components/vi_climate_devices/manifest.json`.
 - Keep `pyproject.toml` package metadata version aligned with

--- a/README.md
+++ b/README.md
@@ -135,16 +135,16 @@ python3.14 -m venv .venv
 source .venv/bin/activate
 python -m pip install --upgrade pip
 python -m pip install '.[dev]'
-pyright --pythonpath .venv/bin/python
-python -m pytest -q
+pre-commit install --install-hooks
 ```
 
 ### Code Quality
 
 ```bash
-ruff check .
-ruff format --check .
-pyright --pythonpath .venv/bin/python
+python scripts/quality_check.py
+
+# Run the same gate manually through pre-commit.
+pre-commit run --all-files
 ```
 
 ---

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ dependencies = [
 
 [project.optional-dependencies]
 dev = [
+    "pre-commit==4.6.2",
     "pyright==1.1.411",
     "pytest-homeassistant-custom-component==0.13.363",
     "ruff==0.16.6",

--- a/scripts/quality_check.py
+++ b/scripts/quality_check.py
@@ -1,0 +1,29 @@
+"""Run the repository's complete local quality gate."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+
+COMMANDS = (
+    (sys.executable, "-m", "ruff", "check", "."),
+    (sys.executable, "-m", "ruff", "format", "--check", "."),
+    (sys.executable, "-m", "pyright", "--pythonpath", sys.executable),
+    (sys.executable, "-m", "pytest", "-q"),
+)
+
+
+def main() -> int:
+    """Run every quality command and stop at the first failure."""
+    for command in COMMANDS:
+        result = subprocess.run(command, cwd=PROJECT_ROOT, check=False)
+        if result.returncode:
+            return result.returncode
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add a versioned pre-commit quality gate
- run Ruff, Pyright, and pytest through one shared runner
- reuse the runner in CI and document the setup

## Validation
- python scripts/quality_check.py
- pre-commit run --all-files
- git hook run pre-commit
- fresh python3.14 environment installed with .[dev]