### PR TITLE
chore: enforce additional code quality rules

### DIFF
--- a/.agent/rules/python-style.md
+++ b/.agent/rules/python-style.md
@@ -8,14 +8,12 @@ These rules apply strictly to all Python files.
 
 ## 1. String Formatting & Logging (CRITICAL)
 - **General:** Use **f-strings** for all string interpolation.
-- **EXCEPTION - Logging:** NEVER use f-strings inside `_LOGGER` calls.
-    - **Reason:** To prevent formatting overhead when logging is disabled.
-    - ❌ Wrong: `_LOGGER.info(f"Device {name} connected")`
-    - ✅ Right: `_LOGGER.info("Device %s connected", name)`
+- **EXCEPTION - Logging:** Ruff enforces that `_LOGGER` calls do not use eager
+  formatting such as f-strings.
 - **Log Content:** Log messages must NOT end with a period `.`.
 
 ## 2. Ordering & Sorting
-- **Imports:** Must be sorted.
+- **Imports and identifiers:** Ruff enforces sorted imports and PEP 8 naming.
 - **Data Structures:** Constants, content of Lists, and Dictionary Keys must be sorted **alphabetically**.
     - If you create a list of supported features, sort them A-Z.
 

--- a/.agent/rules/tech-stack.md
+++ b/.agent/rules/tech-stack.md
@@ -15,9 +15,11 @@ trigger: always_on
 
 ## 3. Static Type Checking
 - Use Pyright with the shared configuration in `pyproject.toml`.
-- Run `pyright --pythonpath .venv/bin/python` locally. The CI workflow passes
-  its active interpreter explicitly.
+- Run `python scripts/quality_check.py` locally. The runner passes its active
+  interpreter to Pyright.
 - Keep the Pylance type-checking mode aligned with Pyright's configured mode.
+- New utility scripts are checked in Pyright strict mode. Expand strict typing
+  to integration modules incrementally once they are clean.
 
 ## 4. Quality Gate
 - Run `python scripts/quality_check.py` for the complete local gate.

--- a/.agent/rules/testing.md
+++ b/.agent/rules/testing.md
@@ -16,6 +16,9 @@ These rules apply strictly to the `tests/` directory of the `vi_climate_devices`
 
 ## 2. Framework & Style
 - **Framework:** Use `pytest` exclusively.
+- **Mechanical pytest style:** Ruff enforces the enabled `PT` rules. Keep
+  behavioral test design requirements in this rule until the TDD workflow is
+  migrated to a shared skill.
 - **Test Stack Ownership:** Treat `pytest-homeassistant-custom-component` as the
   authoritative Home Assistant test stack. Do not separately pin `pytest`,
   `pytest-asyncio`, `syrupy`, or similar pytest ecosystem packages unless there

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,11 +28,12 @@ dev = [
 ]
 
 [tool.pyright]
-include = ["custom_components", "tests"]
+include = ["custom_components", "tests", "scripts"]
 exclude = [".venv", "build", "dist"]
 pythonVersion = "3.14"
 extraPaths = []
 typeCheckingMode = "standard"
+strict = ["scripts"]
 # Home Assistant declares cached properties in base classes, while integrations
 # may validly override them with properties.
 reportIncompatibleVariableOverride = "none"
@@ -50,6 +51,9 @@ select = [
     "I",   # isort
     "UP",  # pyupgrade
     "B",   # flake8-bugbear
+    "G",   # flake8-logging-format
+    "N",   # pep8-naming
+    "PT",  # flake8-pytest-style
     "SIM", # flake8-simplify
     "PL",  # pylint
     "RUF"  # ruff specific

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,7 +12,7 @@ def mock_client():
 
 @pytest.fixture(autouse=True)
 def auto_enable_custom_integrations(enable_custom_integrations):
-    yield
+    return None
 
 
 @pytest.fixture

--- a/tests/test_translations.py
+++ b/tests/test_translations.py
@@ -90,7 +90,8 @@ def test_entity_has_translation_key(platform):
     # Act & Assert: Iterate through all descriptions and verify existence of translation_key.
     for i, desc in enumerate(descriptions):
         key_name = getattr(desc, "key", "UNKNOWN")
-        assert hasattr(desc, "translation_key") and desc.translation_key, (
+        translation_key = getattr(desc, "translation_key", None)
+        assert translation_key, (
             f"EntityDescription at index {i} in {platform} is missing a translation_key. Key: {key_name}"
         )
 


### PR DESCRIPTION
## Summary
- enforce Ruff logging, naming, and pytest-style rules
- check the quality runner with Pyright strict mode
- fix the two newly detected pytest-style findings

## Validation
- python scripts/quality_check.py
- git hook run pre-commit