### PR TITLE
Preserve regular polling after successful commands

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -107,6 +107,9 @@ or explicitly state that no update was needed.
 Issues and specs live in this repository's GitHub Issues. See
 `docs/agents/issue-tracker.md`.
 
+Write GitHub issues, tickets, and specifications in English, even when the
+surrounding conversation is in another language.
+
 ### Triage labels
 
 Use the canonical triage-label vocabulary. See

--- a/README.md
+++ b/README.md
@@ -106,7 +106,9 @@ All entities are grouped under their respective device and support German and En
 
 **Entities not updating**
 - Check if your Viessmann gateway is online
-- API rate limit is respected (default: 3-minute polling interval)
+- Device measurements are polled every 3 minutes. Commands and polls are serialized; an in-flight request can delay the next request, but successful commands do not restart the polling interval.
+- Confirmed command values are published immediately. A successful command does not clear an outage: availability is restored only by successful device refreshes.
+- The polling interval alone does not guarantee API rate-limit compliance; total requests also depend on device count and command frequency.
 
 **Missing entities**
 - Not all features are available on all device models

--- a/custom_components/vi_climate_devices/coordinator.py
+++ b/custom_components/vi_climate_devices/coordinator.py
@@ -73,7 +73,10 @@ class ViClimateDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Device]]):
                     updated_data = dict(self.data)
                     updated_data[device_key] = updated_device
                     self._known_devices = list(updated_data.values())
-                    self.async_set_updated_data(updated_data)
+                    # A command confirms values, not refresh availability. Preserve
+                    # the scheduled poll and the outcome of the last refresh.
+                    self.data = updated_data
+                    self.async_update_listeners()
                 return response
 
     async def _async_refresh(

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -2,6 +2,7 @@
 
 import asyncio
 from dataclasses import replace
+from datetime import timedelta
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
@@ -14,6 +15,7 @@ from homeassistant.exceptions import (
     OAuth2TokenRequestReauthError,
 )
 from homeassistant.helpers.update_coordinator import UpdateFailed
+from pytest_homeassistant_custom_component.common import async_fire_time_changed
 from vi_api_client import Device, Feature, ViAuthError, ViConnectionError
 from vi_api_client.models import CommandResponse
 
@@ -528,4 +530,129 @@ async def test_data_coordinator_notifies_entities_after_successful_write(
         # Assert: Every coordinator entity receives the new immutable device object.
         assert listener_data == [updated_device]
     finally:
+        await coordinator.async_shutdown()
+
+
+@pytest.mark.asyncio
+async def test_frequent_writes_preserve_scheduled_poll(
+    hass: HomeAssistant, mock_client, freezer
+) -> None:
+    """Commands publish immediately without postponing measurement refreshes."""
+    coordinator = ViClimateDataUpdateCoordinator(hass, mock_client)
+    await coordinator.async_refresh()
+    device_key = next(iter(coordinator.data))
+    feature_name = "heating.circuits.0.heating.curve.slope"
+    listener = MagicMock()
+    remove_listener = coordinator.async_add_listener(listener)
+    mock_client.update_device = AsyncMock(wraps=mock_client.update_device)
+
+    try:
+        # Act: Keep issuing commands more frequently than the three-minute poll.
+        for minute in range(1, 7):
+            freezer.tick(timedelta(minutes=1))
+            async_fire_time_changed(hass)
+            await hass.async_block_till_done()
+            await coordinator.async_set_feature(device_key, feature_name, 1.2)
+
+            # Assert: Each command notifies immediately; polls still happen on time.
+            assert listener.call_count == minute + minute // 3
+            assert mock_client.update_device.await_count == minute // 3
+            feature = coordinator.data[device_key].get_feature(feature_name)
+            assert feature is not None
+            assert feature.value == 1.2
+    finally:
+        remove_listener()
+        await coordinator.async_shutdown()
+
+    # No poll or notification survives removal and shutdown.
+    listener.reset_mock()
+    mock_client.update_device.reset_mock()
+    freezer.tick(timedelta(minutes=6))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+    listener.assert_not_called()
+    mock_client.update_device.assert_not_awaited()
+
+
+@pytest.mark.parametrize("is_token_failure", [False, True])
+@pytest.mark.asyncio
+async def test_write_after_full_outage_preserves_availability_until_poll(
+    hass: HomeAssistant, mock_client, freezer, is_token_failure: bool
+) -> None:
+    """Only device refreshes restore availability after device or token failures."""
+    # Arrange: Discover two devices and observe their public entity state.
+    initial_device = _build_curve_device(slope=0.7, shift=0.0)
+    other_device = replace(initial_device, id="device-1")
+    written_device = _build_curve_device(slope=1.2, shift=0.0)
+    mock_client.get_installations = AsyncMock(
+        return_value=[SimpleNamespace(id="installation-1")]
+    )
+    mock_client.get_full_installation_status = AsyncMock(
+        return_value=[initial_device, other_device]
+    )
+    mock_client.update_device = AsyncMock(side_effect=lambda device: device)
+    coordinator = ViClimateDataUpdateCoordinator(hass, mock_client)
+    await coordinator.async_refresh()
+    feature_name = "heating.circuits.0.heating.curve.slope"
+    entity = ViClimateNumber(
+        coordinator,
+        "gw-main_device-0",
+        feature_name,
+        NumberEntityDescription(key=feature_name),
+    )
+    other_entity = ViClimateNumber(
+        coordinator,
+        "gw-main_device-1",
+        feature_name,
+        NumberEntityDescription(key=feature_name),
+    )
+    observed_states: list[tuple[bool, bool, float | None]] = []
+    remove_listener = coordinator.async_add_listener(
+        lambda: observed_states.append(
+            (entity.available, other_entity.available, entity.native_value)
+        )
+    )
+    mock_client.update_device.side_effect = (
+        _make_token_error() if is_token_failure else ViConnectionError("offline")
+    )
+    try:
+        # Act: A scheduled poll fails globally, then a command succeeds.
+        freezer.tick(timedelta(minutes=3))
+        async_fire_time_changed(hass)
+        await hass.async_block_till_done()
+        assert not coordinator.last_update_success
+        last_exception = coordinator.last_exception
+        assert observed_states == [(False, False, 0.7)]
+        mock_client.set_feature = AsyncMock(
+            return_value=(
+                CommandResponse(success=True, message=None, reason=None),
+                written_device,
+            )
+        )
+        await coordinator.async_set_feature("gw-main_device-0", feature_name, 1.2)
+
+        # Assert: Publish confirmed values without claiming either device recovered.
+        assert observed_states[-1] == (False, False, 1.2)
+        assert len(observed_states) == 2
+        assert not coordinator.last_update_success
+        assert coordinator.last_exception is last_exception
+
+        # Act: The next poll confirms only the written device is reachable.
+        mock_client.update_device.side_effect = [
+            written_device,
+            ViConnectionError("other device offline"),
+        ]
+        freezer.tick(timedelta(minutes=3))
+        async_fire_time_changed(hass)
+        await hass.async_block_till_done()
+        assert observed_states[-1] == (True, False, 1.2)
+        assert mock_client.update_device.call_args_list[-2].args[0] is written_device
+
+        mock_client.update_device.side_effect = lambda device: device
+        freezer.tick(timedelta(minutes=3))
+        async_fire_time_changed(hass)
+        await hass.async_block_till_done()
+        assert observed_states[-1] == (True, True, 1.2)
+    finally:
+        remove_listener()
         await coordinator.async_shutdown()

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,5 +1,6 @@
 """Tests for integration setup, unload, and auth bridge behavior."""
 
+from datetime import timedelta
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -10,7 +11,10 @@ from homeassistant.exceptions import (
     OAuth2TokenRequestError,
     OAuth2TokenRequestReauthError,
 )
-from pytest_homeassistant_custom_component.common import MockConfigEntry
+from pytest_homeassistant_custom_component.common import (
+    MockConfigEntry,
+    async_fire_time_changed,
+)
 
 from custom_components.vi_climate_devices import (
     PLATFORMS,
@@ -281,3 +285,57 @@ async def test_haauth_propagates_transient_token_error(
     with pytest.raises(OAuth2TokenRequestError) as raised_error:
         await auth_bridge.async_get_access_token()
     assert raised_error.value is token_error
+
+
+@pytest.mark.asyncio
+async def test_unload_stops_polling_after_commands(
+    hass: HomeAssistant, mock_client, freezer
+) -> None:
+    """Unloading real platforms removes polling after confirmed service writes."""
+    entry = _build_entry()
+    entry.add_to_hass(hass)
+    mock_client.update_device = AsyncMock(wraps=mock_client.update_device)
+    with (
+        patch(
+            "custom_components.vi_climate_devices.ViessmannClient",
+            return_value=mock_client,
+        ),
+        patch(
+            "homeassistant.helpers.config_entry_oauth2_flow.async_get_config_entry_implementation",
+            return_value=MagicMock(),
+        ),
+        patch(
+            "homeassistant.helpers.config_entry_oauth2_flow.OAuth2Session.async_ensure_token_valid",
+            return_value=None,
+        ),
+        patch("custom_components.vi_climate_devices.HAAuth"),
+    ):
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+        entity_id = "number.vitocal250a_heating_circuit_0_curve_slope"
+        await hass.services.async_call(
+            "number",
+            "set_value",
+            {"entity_id": entity_id, "value": 1.2},
+            blocking=True,
+        )
+        state = hass.states.get(entity_id)
+        assert state is not None
+        assert state.state == "1.2"
+
+        # Confirm polling is active before unloading the real entity platforms.
+        mock_client.update_device.reset_mock()
+        freezer.tick(timedelta(minutes=3))
+        async_fire_time_changed(hass)
+        await hass.async_block_till_done()
+        mock_client.update_device.assert_awaited_once()
+        assert await hass.config_entries.async_unload(entry.entry_id)
+        await hass.async_block_till_done()
+
+        # No request remains scheduled after unload, even across several intervals.
+        mock_client.update_device.reset_mock()
+        freezer.tick(timedelta(minutes=9))
+        async_fire_time_changed(hass)
+        await hass.async_block_till_done()
+        mock_client.update_device.assert_not_awaited()
+        assert entry.entry_id not in hass.data[DOMAIN]


### PR DESCRIPTION
## Summary

- Keep scheduled device polling independent of successful feature writes
- Publish confirmed command values immediately without restoring availability
- Document polling, request serialization, and rate-limit behavior
- Add coverage for frequent writes, outage recovery, and unload cleanup

## Testing

- Added coordinator and integration tests covering polling cadence, availability, and shutdown behavior
- Not run (not requested)