### PR TITLE
fix: log device outages and recovery once

### DIFF
--- a/custom_components/vi_climate_devices/coordinator.py
+++ b/custom_components/vi_climate_devices/coordinator.py
@@ -49,6 +49,14 @@ class ViClimateDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Device]]):
         """Return whether the most recent refresh succeeded for a device."""
         return device_key not in self._failed_device_keys
 
+    def _log_device_availability(self, device_key: str, error: ViError | None) -> None:
+        """Log a device availability transition once."""
+        if error is None:
+            if device_key in self._failed_device_keys:
+                _LOGGER.info("Device %s is back online", device_key)
+        elif device_key not in self._failed_device_keys:
+            _LOGGER.info("Device %s is unavailable: %s", device_key, error)
+
     async def async_set_feature(
         self, device_key: str, feature_name: str, value: object
     ) -> CommandResponse:
@@ -165,6 +173,7 @@ class ViClimateDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Device]]):
                     try:
                         new_device = await self.client.update_device(device)
                         updated_data[key] = new_device
+                        self._log_device_availability(key, None)
 
                     except OAuth2TokenRequestError:
                         raise
@@ -176,9 +185,7 @@ class ViClimateDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Device]]):
                         ) from err
 
                     except ViError as err:
-                        _LOGGER.warning(
-                            "Failed to update device %s: %s", device.id, err
-                        )
+                        self._log_device_availability(key, err)
                         failed_device_keys.add(key)
                         # Keep old data for recovery, but mark its entities unavailable.
                         updated_data[key] = device

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -1,6 +1,7 @@
 """Tests for coordinator discovery, refresh, and writes."""
 
 import asyncio
+import logging
 from dataclasses import replace
 from datetime import timedelta
 from types import SimpleNamespace
@@ -207,6 +208,80 @@ async def test_data_coordinator_marks_only_failed_device_unavailable(
     }
     assert coordinator.is_device_available("gw-main_device-0")
     assert not coordinator.is_device_available("gw-backup_device-1")
+
+
+@pytest.mark.asyncio
+async def test_data_coordinator_logs_partial_device_outage_and_recovery_once(
+    hass: HomeAssistant, mock_client, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Test a partial device outage and recovery are each logged once."""
+    # Arrange: Keep one device reachable while the other fails repeatedly.
+    refreshed_device = _build_device(device_id="device-0", gateway_serial="gw-main")
+    failing_device = _build_device(device_id="device-1", gateway_serial="gw-backup")
+    coordinator = ViClimateDataUpdateCoordinator(hass, mock_client)
+    coordinator._known_devices = [refreshed_device, failing_device]
+
+    with caplog.at_level(
+        logging.INFO, logger="custom_components.vi_climate_devices.coordinator"
+    ):
+        # Act: Poll through an outage, repeated failure, and recovery.
+        mock_client.update_device = AsyncMock(
+            side_effect=[refreshed_device, ViConnectionError("device offline")]
+        )
+        await coordinator._async_update_data()
+        assert not coordinator.is_device_available("gw-backup_device-1")
+
+        mock_client.update_device = AsyncMock(
+            side_effect=[refreshed_device, ViConnectionError("device offline")]
+        )
+        await coordinator._async_update_data()
+        assert not coordinator.is_device_available("gw-backup_device-1")
+
+        mock_client.update_device = AsyncMock(
+            side_effect=[refreshed_device, failing_device]
+        )
+        await coordinator._async_update_data()
+
+    # Assert: Device-specific transitions are unambiguous and never repeated.
+    assert coordinator.is_device_available("gw-backup_device-1")
+    assert [record.getMessage() for record in caplog.records] == [
+        "Device gw-backup_device-1 is unavailable: device offline",
+        "Device gw-backup_device-1 is back online",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_data_coordinator_logs_full_device_outage_and_recovery_once(
+    hass: HomeAssistant, mock_client, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Test a full device outage does not repeat device or coordinator logs."""
+    # Arrange: A single known device becomes unreachable for two refreshes.
+    known_device = _build_device(device_id="device-0", gateway_serial="gw-main")
+    coordinator = ViClimateDataUpdateCoordinator(hass, mock_client)
+    coordinator._known_devices = [known_device]
+
+    with caplog.at_level(
+        logging.INFO, logger="custom_components.vi_climate_devices.coordinator"
+    ):
+        # Act: Use coordinator refreshes to include its built-in full-outage logging.
+        mock_client.update_device = AsyncMock(
+            side_effect=ViConnectionError("device offline")
+        )
+        await coordinator.async_refresh()
+        await coordinator.async_refresh()
+        assert not coordinator.is_device_available("gw-main_device-0")
+
+        mock_client.update_device = AsyncMock(return_value=known_device)
+        await coordinator.async_refresh()
+
+    # Assert: Each device and coordinator transition is emitted once.
+    assert coordinator.is_device_available("gw-main_device-0")
+    assert [record.getMessage() for record in caplog.records] == [
+        "Device gw-main_device-0 is unavailable: device offline",
+        "Error fetching vi_climate_devices_data data: Failed to update all devices",
+        "Device gw-main_device-0 is back online",
+        "Fetching vi_climate_devices_data data recovered",
+    ]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Why

Repeated failed polls for an unreachable device emitted a warning on every refresh. This obscured useful diagnostics, especially when only one device was unavailable.

## What Changed

Track device availability transitions in the data coordinator and log each outage and recovery once at `INFO` level. Device log messages use gateway/device keys, and tests cover partial outages, full outages, repeated failures, and recovery.

Closes #108
