### PR TITLE
feat: manage coordinator through config entry

### DIFF
--- a/custom_components/vi_climate_devices/__init__.py
+++ b/custom_components/vi_climate_devices/__init__.py
@@ -16,8 +16,9 @@ from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from vi_api_client import ViClient as ViessmannClient
 from vi_api_client.auth import AbstractAuth
 
-from .const import DOMAIN
 from .coordinator import ViClimateDataUpdateCoordinator
+
+type ViClimateDevicesConfigEntry = ConfigEntry[ViClimateDataUpdateCoordinator]
 
 PLATFORMS: list[Platform] = [
     Platform.BINARY_SENSOR,
@@ -35,10 +36,10 @@ async def async_setup(hass: HomeAssistant, config: dict) -> bool:
     return True
 
 
-async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+async def async_setup_entry(
+    hass: HomeAssistant, entry: ViClimateDevicesConfigEntry
+) -> bool:
     """Set up Viessmann Climate Devices from a config entry."""
-    hass.data.setdefault(DOMAIN, {})
-
     implementation = (
         await config_entry_oauth2_flow.async_get_config_entry_implementation(
             hass, entry
@@ -64,22 +65,21 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     client = ViessmannClient(auth=auth)
 
     # 1. Main Coordinator (Devices API)
-    coordinator = ViClimateDataUpdateCoordinator(hass, client)
+    coordinator = ViClimateDataUpdateCoordinator(hass, entry, client)
     await coordinator.async_config_entry_first_refresh()
 
-    hass.data[DOMAIN][entry.entry_id] = {"data": coordinator}
+    entry.runtime_data = coordinator
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
     return True
 
 
-async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+async def async_unload_entry(
+    hass: HomeAssistant, entry: ViClimateDevicesConfigEntry
+) -> bool:
     """Unload a config entry."""
-    if unload_ok := await hass.config_entries.async_unload_platforms(entry, PLATFORMS):
-        hass.data[DOMAIN].pop(entry.entry_id)
-
-    return unload_ok
+    return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
 
 
 class HAAuth(AbstractAuth):

--- a/custom_components/vi_climate_devices/binary_sensor.py
+++ b/custom_components/vi_climate_devices/binary_sensor.py
@@ -11,13 +11,13 @@ from homeassistant.components.binary_sensor import (
     BinarySensorEntity,
     BinarySensorEntityDescription,
 )
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from vi_api_client.api import Feature
 
+from . import ViClimateDevicesConfigEntry
 from .const import DOMAIN, IGNORED_FEATURES, TESTED_DEVICES
 from .coordinator import ViClimateDataUpdateCoordinator
 from .entity import ViClimateEntity
@@ -149,12 +149,11 @@ def _get_binary_sensor_entity_description(
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    entry: ConfigEntry,
+    entry: ViClimateDevicesConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up Viessmann Climate Devices binary sensor based on a config entry."""
-    coords = hass.data[DOMAIN][entry.entry_id]
-    coordinator: ViClimateDataUpdateCoordinator = coords["data"]
+    coordinator = entry.runtime_data
 
     entities = []
 

--- a/custom_components/vi_climate_devices/climate.py
+++ b/custom_components/vi_climate_devices/climate.py
@@ -17,7 +17,6 @@ from homeassistant.components.climate.const import (
     HVACAction,
     HVACMode,
 )
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import ATTR_TEMPERATURE, UnitOfTemperature
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
@@ -25,6 +24,7 @@ from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from vi_api_client import Feature
 
+from . import ViClimateDevicesConfigEntry
 from .const import DOMAIN
 from .coordinator import ViClimateDataUpdateCoordinator
 from .entity import ViClimateEntity
@@ -91,12 +91,11 @@ API_TO_HA_PRESET = {
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    entry: ConfigEntry,
+    entry: ViClimateDevicesConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up Viessmann Climate Devices climate entities based on a config entry."""
-    coords = hass.data[DOMAIN][entry.entry_id]
-    coordinator: ViClimateDataUpdateCoordinator = coords["data"]
+    coordinator = entry.runtime_data
 
     entities = []
 

--- a/custom_components/vi_climate_devices/coordinator.py
+++ b/custom_components/vi_climate_devices/coordinator.py
@@ -6,6 +6,7 @@ import asyncio
 import logging
 from datetime import timedelta
 
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryAuthFailed, OAuth2TokenRequestError
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
@@ -29,6 +30,7 @@ class ViClimateDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Device]]):
     def __init__(
         self,
         hass: HomeAssistant,
+        entry: ConfigEntry[ViClimateDataUpdateCoordinator],
         client: ViessmannClient,
         update_interval: timedelta | None = None,
     ) -> None:
@@ -36,6 +38,7 @@ class ViClimateDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Device]]):
         super().__init__(
             hass,
             _LOGGER,
+            config_entry=entry,
             name=f"{DOMAIN}_data",
             update_interval=update_interval or timedelta(minutes=3),
         )

--- a/custom_components/vi_climate_devices/number.py
+++ b/custom_components/vi_climate_devices/number.py
@@ -13,7 +13,6 @@ from homeassistant.components.number import (
     NumberEntityDescription,
     NumberMode,
 )
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import EntityCategory, UnitOfTemperature
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
@@ -21,6 +20,7 @@ from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from vi_api_client import Feature
 
+from . import ViClimateDevicesConfigEntry
 from .const import DOMAIN, IGNORED_FEATURES, TESTED_DEVICES
 from .coordinator import ViClimateDataUpdateCoordinator
 from .entity import ViClimateEntity
@@ -179,12 +179,11 @@ def _get_number_entity_description(
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    entry: ConfigEntry,
+    entry: ViClimateDevicesConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up Viessmann Climate Devices number based on a config entry."""
-    coords = hass.data[DOMAIN][entry.entry_id]
-    coordinator: ViClimateDataUpdateCoordinator = coords["data"]
+    coordinator = entry.runtime_data
 
     entities = []
 

--- a/custom_components/vi_climate_devices/select.py
+++ b/custom_components/vi_climate_devices/select.py
@@ -7,7 +7,6 @@ import logging
 import re
 
 from homeassistant.components.select import SelectEntity, SelectEntityDescription
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
@@ -15,6 +14,7 @@ from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from vi_api_client import Feature
 
+from . import ViClimateDevicesConfigEntry
 from .const import DOMAIN, IGNORED_FEATURES, TESTED_DEVICES
 from .coordinator import ViClimateDataUpdateCoordinator
 from .entity import ViClimateEntity
@@ -73,12 +73,11 @@ def _get_select_entity_description(
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    entry: ConfigEntry,
+    entry: ViClimateDevicesConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up Viessmann Climate Devices select based on a config entry."""
-    coords = hass.data[DOMAIN][entry.entry_id]
-    coordinator: ViClimateDataUpdateCoordinator = coords["data"]
+    coordinator = entry.runtime_data
 
     entities = []
 

--- a/custom_components/vi_climate_devices/sensor.py
+++ b/custom_components/vi_climate_devices/sensor.py
@@ -13,7 +13,6 @@ from homeassistant.components.sensor import (
     SensorEntityDescription,
     SensorStateClass,
 )
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     EntityCategory,
     UnitOfElectricCurrent,
@@ -28,6 +27,7 @@ from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from vi_api_client.api import Feature
 
+from . import ViClimateDevicesConfigEntry
 from .const import DOMAIN, IGNORED_FEATURES, TESTED_DEVICES
 from .coordinator import ViClimateDataUpdateCoordinator
 from .entity import ViClimateEntity
@@ -693,13 +693,11 @@ def _get_auto_discovery_description(feature) -> SensorEntityDescription:
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    entry: ConfigEntry,
+    entry: ViClimateDevicesConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up Viessmann Climate Devices sensor based on a config entry."""
-    coordinator: ViClimateDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id][
-        "data"
-    ]
+    coordinator = entry.runtime_data
     entities = []
     if coordinator.data:
         entities.extend(_discover_realtime_sensors(coordinator))

--- a/custom_components/vi_climate_devices/switch.py
+++ b/custom_components/vi_climate_devices/switch.py
@@ -10,7 +10,6 @@ from homeassistant.components.switch import (
     SwitchEntity,
     SwitchEntityDescription,
 )
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
@@ -18,6 +17,7 @@ from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from vi_api_client import Feature
 
+from . import ViClimateDevicesConfigEntry
 from .const import DOMAIN, IGNORED_FEATURES, TESTED_DEVICES
 from .coordinator import ViClimateDataUpdateCoordinator
 from .entity import ViClimateEntity
@@ -50,12 +50,11 @@ SWITCH_TYPES: dict[str, SwitchEntityDescription] = {
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    entry: ConfigEntry,
+    entry: ViClimateDevicesConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up Viessmann Climate Devices switch based on a config entry."""
-    coords = hass.data[DOMAIN][entry.entry_id]
-    coordinator: ViClimateDataUpdateCoordinator = coords["data"]
+    coordinator = entry.runtime_data
 
     entities = []
 

--- a/custom_components/vi_climate_devices/water_heater.py
+++ b/custom_components/vi_climate_devices/water_heater.py
@@ -13,7 +13,6 @@ from homeassistant.components.water_heater import (
     WaterHeaterEntity,
     WaterHeaterEntityFeature,
 )
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import ATTR_TEMPERATURE, STATE_OFF, UnitOfTemperature
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
@@ -21,6 +20,7 @@ from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from vi_api_client import Feature
 
+from . import ViClimateDevicesConfigEntry
 from .const import DOMAIN
 from .coordinator import ViClimateDataUpdateCoordinator
 from .entity import ViClimateEntity
@@ -59,12 +59,11 @@ HA_TO_VIESSMANN_MODES = {
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    entry: ConfigEntry,
+    entry: ViClimateDevicesConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up Viessmann Climate Devices water heater."""
-    coords = hass.data[DOMAIN][entry.entry_id]
-    coordinator: ViClimateDataUpdateCoordinator = coords["data"]
+    coordinator = entry.runtime_data
 
     entities = []
 

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -16,14 +16,24 @@ from homeassistant.exceptions import (
     OAuth2TokenRequestReauthError,
 )
 from homeassistant.helpers.update_coordinator import UpdateFailed
-from pytest_homeassistant_custom_component.common import async_fire_time_changed
-from vi_api_client import Device, Feature, ViAuthError, ViConnectionError
+from pytest_homeassistant_custom_component.common import (
+    MockConfigEntry,
+    async_fire_time_changed,
+)
+from vi_api_client import Device, Feature, ViAuthError, ViClient, ViConnectionError
 from vi_api_client.models import CommandResponse
 
 from custom_components.vi_climate_devices.coordinator import (
     ViClimateDataUpdateCoordinator,
 )
 from custom_components.vi_climate_devices.number import ViClimateNumber
+
+
+def _build_coordinator(
+    hass: HomeAssistant, client: ViClient
+) -> ViClimateDataUpdateCoordinator:
+    """Create a coordinator with an explicit config entry for unit tests."""
+    return ViClimateDataUpdateCoordinator(hass, MockConfigEntry(), client)
 
 
 def _build_device(
@@ -111,7 +121,7 @@ async def test_data_coordinator_raises_when_no_installations_exist(
     """Test discovery raises UpdateFailed when the account has no installations."""
     # Arrange: Return an empty installation list from the Viessmann client.
     mock_client.get_installations = AsyncMock(return_value=[])
-    coordinator = ViClimateDataUpdateCoordinator(hass, mock_client)
+    coordinator = _build_coordinator(hass, mock_client)
 
     # Act and Assert: The first refresh aborts with a clear update failure.
     with pytest.raises(UpdateFailed, match="No installations found"):
@@ -125,7 +135,7 @@ async def test_data_coordinator_raises_reauth_when_installation_lookup_loses_aut
     """Test discovery triggers reauth when listing installations loses auth."""
     # Arrange: Reject the initial installation lookup with an auth failure.
     mock_client.get_installations = AsyncMock(side_effect=ViAuthError("token expired"))
-    coordinator = ViClimateDataUpdateCoordinator(hass, mock_client)
+    coordinator = _build_coordinator(hass, mock_client)
 
     # Act and Assert: Convert the discovery auth failure into a reauth trigger.
     with pytest.raises(ConfigEntryAuthFailed, match="token expired"):
@@ -151,7 +161,7 @@ async def test_data_coordinator_discovers_devices_and_filters_ignored_ids(
         return_value=[active_device, ignored_device]
     )
     mock_client.update_device = AsyncMock(return_value=active_device)
-    coordinator = ViClimateDataUpdateCoordinator(hass, mock_client)
+    coordinator = _build_coordinator(hass, mock_client)
 
     # Act: Run the first coordinator refresh with discovery enabled.
     result = await coordinator._async_update_data()
@@ -171,7 +181,7 @@ async def test_data_coordinator_raises_when_all_device_updates_fail(
     mock_client.update_device = AsyncMock(
         side_effect=ViConnectionError("device offline")
     )
-    coordinator = ViClimateDataUpdateCoordinator(hass, mock_client)
+    coordinator = _build_coordinator(hass, mock_client)
     coordinator._known_devices = [known_device]
 
     # Act and Assert: Treat the failed poll as an unavailable coordinator update.
@@ -194,7 +204,7 @@ async def test_data_coordinator_marks_only_failed_device_unavailable(
     mock_client.update_device = AsyncMock(
         side_effect=[refreshed_device, ViConnectionError("device offline")]
     )
-    coordinator = ViClimateDataUpdateCoordinator(hass, mock_client)
+    coordinator = _build_coordinator(hass, mock_client)
     coordinator._known_devices = [refreshed_device, failing_device]
     coordinator._failed_device_keys = {"gw-main_device-0"}
 
@@ -218,7 +228,7 @@ async def test_data_coordinator_logs_partial_device_outage_and_recovery_once(
     # Arrange: Keep one device reachable while the other fails repeatedly.
     refreshed_device = _build_device(device_id="device-0", gateway_serial="gw-main")
     failing_device = _build_device(device_id="device-1", gateway_serial="gw-backup")
-    coordinator = ViClimateDataUpdateCoordinator(hass, mock_client)
+    coordinator = _build_coordinator(hass, mock_client)
     coordinator._known_devices = [refreshed_device, failing_device]
 
     with caplog.at_level(
@@ -257,7 +267,7 @@ async def test_data_coordinator_logs_full_device_outage_and_recovery_once(
     """Test a full device outage does not repeat device or coordinator logs."""
     # Arrange: A single known device becomes unreachable for two refreshes.
     known_device = _build_device(device_id="device-0", gateway_serial="gw-main")
-    coordinator = ViClimateDataUpdateCoordinator(hass, mock_client)
+    coordinator = _build_coordinator(hass, mock_client)
     coordinator._known_devices = [known_device]
 
     with caplog.at_level(
@@ -292,7 +302,7 @@ async def test_data_coordinator_raises_reauth_when_device_update_loses_auth(
     # Arrange: Seed one known device and make the update raise ViAuthError.
     known_device = _build_device(device_id="device-0", gateway_serial="gw-main")
     mock_client.update_device = AsyncMock(side_effect=ViAuthError("token expired"))
-    coordinator = ViClimateDataUpdateCoordinator(hass, mock_client)
+    coordinator = _build_coordinator(hass, mock_client)
     coordinator._known_devices = [known_device]
 
     # Act and Assert: The auth failure is escalated to Home Assistant reauth.
@@ -309,7 +319,7 @@ async def test_data_coordinator_propagates_oauth_reauth_error(
     known_device = _build_device(device_id="device-0", gateway_serial="gw-main")
     reauth_error = _make_reauth_error()
     mock_client.update_device = AsyncMock(side_effect=reauth_error)
-    coordinator = ViClimateDataUpdateCoordinator(hass, mock_client)
+    coordinator = _build_coordinator(hass, mock_client)
     coordinator._known_devices = [known_device]
 
     # Act and Assert: Home Assistant receives the original reauth-class error.
@@ -327,7 +337,7 @@ async def test_data_coordinator_propagates_transient_oauth_error(
     known_device = _build_device(device_id="device-0", gateway_serial="gw-main")
     token_error = _make_token_error()
     mock_client.update_device = AsyncMock(side_effect=token_error)
-    coordinator = ViClimateDataUpdateCoordinator(hass, mock_client)
+    coordinator = _build_coordinator(hass, mock_client)
     coordinator._known_devices = [known_device]
 
     # Act and Assert: Home Assistant receives the original retryable error.
@@ -357,7 +367,7 @@ async def test_confirmed_write_survives_partial_failure_and_recovery(
         return_value=[initial_device, other_device]
     )
     mock_client.update_device = AsyncMock(side_effect=[initial_device, other_device])
-    coordinator = ViClimateDataUpdateCoordinator(hass, mock_client)
+    coordinator = _build_coordinator(hass, mock_client)
     await coordinator.async_refresh()
     entity = ViClimateNumber(
         coordinator, device_key, feature_name, NumberEntityDescription(key=feature_name)
@@ -431,7 +441,7 @@ async def test_refresh_waits_for_write_and_polls_confirmed_device(
         return_value=[initial_device, other_device]
     )
     mock_client.update_device = AsyncMock(side_effect=[initial_device, other_device])
-    coordinator = ViClimateDataUpdateCoordinator(hass, mock_client)
+    coordinator = _build_coordinator(hass, mock_client)
     await coordinator.async_refresh()
     write_started = asyncio.Event()
     allow_write_to_finish = asyncio.Event()
@@ -491,7 +501,7 @@ async def test_data_coordinator_serializes_writes_per_device(
         return CommandResponse(success=True, message=None, reason=None), final_device
 
     mock_client.set_feature = AsyncMock(side_effect=mock_set_feature)
-    coordinator = ViClimateDataUpdateCoordinator(hass, mock_client)
+    coordinator = _build_coordinator(hass, mock_client)
     coordinator.data = {device_key: initial_device}
 
     # Act: Start two writes for command parameters sharing one device.
@@ -545,7 +555,7 @@ async def test_data_coordinator_does_not_overwrite_a_write_with_stale_refresh(
             written_device,
         )
     )
-    coordinator = ViClimateDataUpdateCoordinator(hass, mock_client)
+    coordinator = _build_coordinator(hass, mock_client)
     coordinator.data = {device_key: initial_device}
     coordinator._known_devices = [initial_device]
 
@@ -587,7 +597,7 @@ async def test_data_coordinator_notifies_entities_after_successful_write(
             updated_device,
         )
     )
-    coordinator = ViClimateDataUpdateCoordinator(hass, mock_client)
+    coordinator = _build_coordinator(hass, mock_client)
     coordinator.data = {device_key: initial_device}
     listener_data: list[Device] = []
     coordinator.async_add_listener(
@@ -613,7 +623,7 @@ async def test_frequent_writes_preserve_scheduled_poll(
     hass: HomeAssistant, mock_client, freezer
 ) -> None:
     """Commands publish immediately without postponing measurement refreshes."""
-    coordinator = ViClimateDataUpdateCoordinator(hass, mock_client)
+    coordinator = _build_coordinator(hass, mock_client)
     await coordinator.async_refresh()
     device_key = next(iter(coordinator.data))
     feature_name = "heating.circuits.0.heating.curve.slope"
@@ -666,7 +676,7 @@ async def test_write_after_full_outage_preserves_availability_until_poll(
         return_value=[initial_device, other_device]
     )
     mock_client.update_device = AsyncMock(side_effect=lambda device: device)
-    coordinator = ViClimateDataUpdateCoordinator(hass, mock_client)
+    coordinator = _build_coordinator(hass, mock_client)
     await coordinator.async_refresh()
     feature_name = "heating.circuits.0.heating.curve.slope"
     entity = ViClimateNumber(

--- a/tests/test_entity.py
+++ b/tests/test_entity.py
@@ -2,6 +2,7 @@
 
 from homeassistant.components.sensor import SensorEntityDescription
 from homeassistant.core import HomeAssistant
+from pytest_homeassistant_custom_component.common import MockConfigEntry
 from vi_api_client import Device, Feature
 
 from custom_components.vi_climate_devices.coordinator import (
@@ -38,7 +39,7 @@ def test_entity_is_unavailable_when_its_device_refresh_fails(
     # Arrange: Create an enabled sensor for a successfully refreshed device.
     device = _build_device()
     device_key = "gw-main_device-0"
-    coordinator = ViClimateDataUpdateCoordinator(hass, mock_client)
+    coordinator = ViClimateDataUpdateCoordinator(hass, MockConfigEntry(), mock_client)
     coordinator.data = {device_key: device}
     entity = ViClimateSensor(
         coordinator,

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -15,12 +15,12 @@ from pytest_homeassistant_custom_component.common import (
     MockConfigEntry,
     async_fire_time_changed,
 )
+from vi_api_client.mock_client import MockViClient
 
 from custom_components.vi_climate_devices import (
     PLATFORMS,
     HAAuth,
     async_setup_entry,
-    async_unload_entry,
 )
 from custom_components.vi_climate_devices.const import DOMAIN
 
@@ -112,11 +112,11 @@ async def test_async_setup_entry_raises_not_ready_on_transient_token_error(
         await async_setup_entry(hass, entry)
 
     # Assert: Setup leaves no runtime data while Home Assistant schedules a retry.
-    assert hass.data[DOMAIN] == {}
+    assert DOMAIN not in hass.data
 
 
 @pytest.mark.asyncio
-async def test_async_setup_entry_stores_only_main_coordinator(
+async def test_async_setup_entry_stores_coordinator_in_entry_runtime_data(
     hass: HomeAssistant,
 ) -> None:
     """Test setup stores only the main coordinator in runtime data."""
@@ -126,8 +126,13 @@ async def test_async_setup_entry_stores_only_main_coordinator(
     client = MagicMock()
     auth_bridge = MagicMock()
     main_coordinator = MagicMock()
-    main_coordinator.async_config_entry_first_refresh = AsyncMock(return_value=None)
-    forward_entry_setups = AsyncMock(return_value=None)
+    call_order: list[str] = []
+    main_coordinator.async_config_entry_first_refresh = AsyncMock(
+        side_effect=lambda: call_order.append("refresh")
+    )
+    forward_entry_setups = AsyncMock(
+        side_effect=lambda *_: call_order.append("platforms")
+    )
 
     with (
         patch(
@@ -149,7 +154,7 @@ async def test_async_setup_entry_stores_only_main_coordinator(
         patch(
             "custom_components.vi_climate_devices.ViClimateDataUpdateCoordinator",
             return_value=main_coordinator,
-        ),
+        ) as mock_coordinator_class,
         patch.object(
             hass.config_entries,
             "async_forward_entry_setups",
@@ -159,53 +164,57 @@ async def test_async_setup_entry_stores_only_main_coordinator(
         # Act: Set up the integration and store runtime data for the entry.
         result = await async_setup_entry(hass, entry)
 
-    # Assert: Setup succeeds, stores the main coordinator, and forwards all platforms.
+    # Assert: Setup succeeds, stores the coordinator on the entry, and forwards all platforms.
     assert result is True
-    assert hass.data[DOMAIN][entry.entry_id] == {"data": main_coordinator}
+    assert entry.runtime_data is main_coordinator
+    assert DOMAIN not in hass.data
     mock_client_class.assert_called_once_with(auth=auth_bridge)
+    mock_coordinator_class.assert_called_once_with(hass, entry, client)
     main_coordinator.async_config_entry_first_refresh.assert_awaited_once()
     forward_entry_setups.assert_awaited_once_with(entry, PLATFORMS)
+    assert call_order == ["refresh", "platforms"]
 
 
 @pytest.mark.asyncio
-async def test_async_unload_entry_removes_runtime_data_after_platform_unload(
-    hass: HomeAssistant,
+async def test_config_entry_lifecycle_keeps_runtime_data_when_platform_unload_fails(
+    hass: HomeAssistant, mock_client: MockViClient
 ) -> None:
-    """Test unloading removes stored runtime data when platform unload succeeds."""
-    # Arrange: Seed runtime data and make platform unload succeed.
+    """Test a failed platform unload keeps the coordinator attached to the entry."""
     entry = _build_entry()
-    hass.data.setdefault(DOMAIN, {})[entry.entry_id] = {"data": MagicMock()}
-    unload_platforms = AsyncMock(return_value=True)
+    entry.add_to_hass(hass)
 
-    with patch.object(hass.config_entries, "async_unload_platforms", unload_platforms):
-        # Act: Unload the config entry.
-        result = await async_unload_entry(hass, entry)
+    with (
+        patch(
+            "custom_components.vi_climate_devices.ViessmannClient",
+            return_value=mock_client,
+        ),
+        patch(
+            "homeassistant.helpers.config_entry_oauth2_flow.async_get_config_entry_implementation",
+            return_value=MagicMock(),
+        ),
+        patch(
+            "homeassistant.helpers.config_entry_oauth2_flow.OAuth2Session.async_ensure_token_valid",
+            return_value=None,
+        ),
+        patch("custom_components.vi_climate_devices.HAAuth"),
+    ):
+        # Arrange: Set up the entry through Home Assistant's lifecycle.
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+        runtime_data = entry.runtime_data
+        number_component = hass.data["number"]
+        unload_platform = AsyncMock(return_value=False)
 
-    # Assert: The entry unloads cleanly and runtime data is removed.
-    assert result is True
-    assert entry.entry_id not in hass.data[DOMAIN]
-    unload_platforms.assert_awaited_once_with(entry, PLATFORMS)
-
-
-@pytest.mark.asyncio
-async def test_async_unload_entry_keeps_runtime_data_when_platform_unload_fails(
-    hass: HomeAssistant,
-) -> None:
-    """Test unloading keeps runtime data intact when platform unload fails."""
-    # Arrange: Seed runtime data and make platform unload fail.
-    entry = _build_entry()
-    runtime_data = {"data": MagicMock()}
-    hass.data.setdefault(DOMAIN, {})[entry.entry_id] = runtime_data
-    unload_platforms = AsyncMock(return_value=False)
-
-    with patch.object(hass.config_entries, "async_unload_platforms", unload_platforms):
-        # Act: Attempt to unload the config entry.
-        result = await async_unload_entry(hass, entry)
+        with patch.object(number_component, "async_unload_entry", unload_platform):
+            # Act: Attempt to unload the config entry through Home Assistant.
+            result = await hass.config_entries.async_unload(entry.entry_id)
 
     # Assert: The failure is reported and runtime data stays registered.
     assert result is False
-    assert hass.data[DOMAIN][entry.entry_id] is runtime_data
-    unload_platforms.assert_awaited_once_with(entry, PLATFORMS)
+    assert entry.runtime_data is runtime_data
+    assert DOMAIN not in hass.data
+    unload_platform.assert_awaited_once_with(entry)
+    await runtime_data.async_shutdown()
 
 
 @pytest.mark.asyncio
@@ -289,7 +298,7 @@ async def test_haauth_propagates_transient_token_error(
 
 @pytest.mark.asyncio
 async def test_unload_stops_polling_after_commands(
-    hass: HomeAssistant, mock_client, freezer
+    hass: HomeAssistant, mock_client: MockViClient, freezer
 ) -> None:
     """Unloading real platforms removes polling after confirmed service writes."""
     entry = _build_entry()
@@ -312,6 +321,9 @@ async def test_unload_stops_polling_after_commands(
     ):
         assert await hass.config_entries.async_setup(entry.entry_id)
         await hass.async_block_till_done()
+        first_coordinator = entry.runtime_data
+        assert first_coordinator.config_entry is entry
+        assert DOMAIN not in hass.data
         entity_id = "number.vitocal250a_heating_circuit_0_curve_slope"
         await hass.services.async_call(
             "number",
@@ -329,8 +341,22 @@ async def test_unload_stops_polling_after_commands(
         async_fire_time_changed(hass)
         await hass.async_block_till_done()
         mock_client.update_device.assert_awaited_once()
+
+        # Reload the same entry and verify it owns one fresh coordinator.
+        assert await hass.config_entries.async_reload(entry.entry_id)
+        await hass.async_block_till_done()
+        second_coordinator = entry.runtime_data
+        assert second_coordinator is not first_coordinator
+
+        mock_client.update_device.reset_mock()
+        freezer.tick(timedelta(minutes=3))
+        async_fire_time_changed(hass)
+        await hass.async_block_till_done()
+        mock_client.update_device.assert_awaited_once()
+
         assert await hass.config_entries.async_unload(entry.entry_id)
         await hass.async_block_till_done()
+        assert not hasattr(entry, "runtime_data")
 
         # No request remains scheduled after unload, even across several intervals.
         mock_client.update_device.reset_mock()
@@ -338,4 +364,3 @@ async def test_unload_stops_polling_after_commands(
         async_fire_time_changed(hass)
         await hass.async_block_till_done()
         mock_client.update_device.assert_not_awaited()
-        assert entry.entry_id not in hass.data[DOMAIN]


### PR DESCRIPTION
## Why

The integration kept its coordinator in a parallel `hass.data` store, while the coordinator itself relied on Home Assistant context to identify its config entry. That split made platform access and config-entry lifecycle ownership less explicit and fragile during unload/reload.

## What Changed

- Store the coordinator in typed `ConfigEntry.runtime_data` and use that path from all seven platforms.
- Pass the config entry explicitly to `ViClimateDataUpdateCoordinator` and its `DataUpdateCoordinator` base.
- Preserve first-refresh ordering and existing OAuth failure handling.
- Exercise setup, successful unload, failed platform unload, and reload through the real Home Assistant ConfigEntry lifecycle.

Closes #109

## Verification

`python scripts/quality_check.py` passes: Ruff, formatting, Pyright, 92 tests, and the discovery snapshot.
