### PR TITLE
fix: declare entity platform parallelism

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ All entities are grouped under their respective device and support German and En
 **Entities not updating**
 - Check if your Viessmann gateway is online
 - Device measurements are polled every 3 minutes. Commands and polls are serialized; an in-flight request can delay the next request, but successful commands do not restart the polling interval.
+- Every entity platform declares `PARALLEL_UPDATES = 0`: read-only entities use the shared coordinator, and command entities rely on its central serialization for writes and polls.
 - Confirmed command values are published immediately. A successful command does not clear an outage: availability is restored only by successful device refreshes.
 - The polling interval alone does not guarantee API rate-limit compliance; total requests also depend on device count and command frequency.
 

--- a/custom_components/vi_climate_devices/binary_sensor.py
+++ b/custom_components/vi_climate_devices/binary_sensor.py
@@ -30,6 +30,8 @@ from .utils import (
 
 _LOGGER = logging.getLogger(__name__)
 
+PARALLEL_UPDATES = 0
+
 
 # Templates with regex patterns for dynamic feature names
 BINARY_SENSOR_TEMPLATES = [

--- a/custom_components/vi_climate_devices/climate.py
+++ b/custom_components/vi_climate_devices/climate.py
@@ -32,6 +32,8 @@ from .utils import get_suggested_precision
 
 _LOGGER = logging.getLogger(__name__)
 
+PARALLEL_UPDATES = 0
+
 # Mapping from Viessmann demand directions to Home Assistant HVACAction.
 # Sort the keys alphabetically.
 API_TO_HA_HVAC_ACTION = {

--- a/custom_components/vi_climate_devices/number.py
+++ b/custom_components/vi_climate_devices/number.py
@@ -28,6 +28,8 @@ from .utils import beautify_name, get_suggested_precision, is_feature_ignored
 
 _LOGGER = logging.getLogger(__name__)
 
+PARALLEL_UPDATES = 0
+
 
 # Templates with regex patterns for dynamic feature names
 NUMBER_TEMPLATES = [

--- a/custom_components/vi_climate_devices/select.py
+++ b/custom_components/vi_climate_devices/select.py
@@ -22,6 +22,8 @@ from .utils import beautify_name, is_feature_ignored
 
 _LOGGER = logging.getLogger(__name__)
 
+PARALLEL_UPDATES = 0
+
 
 SELECT_TYPES: dict[str, SelectEntityDescription] = {
     "heating.dhw.operating.modes.active": SelectEntityDescription(

--- a/custom_components/vi_climate_devices/sensor.py
+++ b/custom_components/vi_climate_devices/sensor.py
@@ -35,6 +35,8 @@ from .utils import beautify_name, is_feature_boolean_like, is_feature_ignored
 
 _LOGGER = logging.getLogger(__name__)
 
+PARALLEL_UPDATES = 0
+
 
 # Templates with regex patterns for dynamic feature names
 SENSOR_TEMPLATES = [

--- a/custom_components/vi_climate_devices/switch.py
+++ b/custom_components/vi_climate_devices/switch.py
@@ -30,6 +30,8 @@ from .utils import (
 
 _LOGGER = logging.getLogger(__name__)
 
+PARALLEL_UPDATES = 0
+
 
 SWITCH_TYPES: dict[str, SwitchEntityDescription] = {
     # Updated keys for Flat Architecture

--- a/custom_components/vi_climate_devices/water_heater.py
+++ b/custom_components/vi_climate_devices/water_heater.py
@@ -28,6 +28,8 @@ from .utils import get_suggested_precision
 
 _LOGGER = logging.getLogger(__name__)
 
+PARALLEL_UPDATES = 0
+
 # Features to look for
 FEATURE_TARGET_TEMP = "heating.dhw.temperature.main"
 FEATURE_CURRENT_TEMP = "heating.dhw.sensors.temperature.hotWaterStorage"

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -5,10 +5,12 @@ import logging
 from dataclasses import replace
 from datetime import timedelta
 from types import SimpleNamespace
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from homeassistant.components.number import NumberEntityDescription
+from homeassistant.components.select import SelectEntityDescription
+from homeassistant.components.switch import SwitchEntityDescription
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import (
     ConfigEntryAuthFailed,
@@ -27,6 +29,8 @@ from custom_components.vi_climate_devices.coordinator import (
     ViClimateDataUpdateCoordinator,
 )
 from custom_components.vi_climate_devices.number import ViClimateNumber
+from custom_components.vi_climate_devices.select import ViClimateSelect
+from custom_components.vi_climate_devices.switch import ViClimateSwitch
 
 
 def _build_coordinator(
@@ -107,6 +111,36 @@ def _build_curve_device(slope: float, shift: float) -> Device:
                 name="heating.circuits.0.heating.curve.slope",
                 value=slope,
                 unit="celsius",
+                is_enabled=True,
+                is_ready=True,
+            ),
+        ],
+    )
+
+
+def _build_select_and_switch_device(
+    active_program: str, is_one_time_charge_active: bool
+) -> Device:
+    """Create a device exposing commands on the select and switch platforms."""
+    return Device(
+        id="device-0",
+        gateway_serial="gw-main",
+        installation_id="installation-1",
+        model_id="Vitocal250A",
+        device_type="heating",
+        status="online",
+        features=[
+            Feature(
+                name="heating.circuits.0.operating.programs.active",
+                value=active_program,
+                unit="",
+                is_enabled=True,
+                is_ready=True,
+            ),
+            Feature(
+                name="heating.dhw.oneTimeCharge.active",
+                value=is_one_time_charge_active,
+                unit="",
                 is_enabled=True,
                 is_ready=True,
             ),
@@ -528,6 +562,71 @@ async def test_data_coordinator_serializes_writes_per_device(
     assert calls[1][0] is slope_updated_device
     assert calls[1][1].value == 0.0
     assert coordinator.data[device_key] is final_device
+
+
+@pytest.mark.asyncio
+async def test_platform_commands_share_current_device_state(
+    hass: HomeAssistant, mock_client
+) -> None:
+    """Test select and switch actions serialize through the shared coordinator."""
+    # Arrange: Block a select command before dispatching a switch command.
+    device_key = "gw-main_device-0"
+    select_feature_name = "heating.circuits.0.operating.programs.active"
+    switch_feature_name = "heating.dhw.oneTimeCharge.active"
+    initial_device = _build_select_and_switch_device("eco", False)
+    select_updated_device = _build_select_and_switch_device("heating", False)
+    final_device = _build_select_and_switch_device("heating", True)
+    first_write_started = asyncio.Event()
+    allow_first_write_to_finish = asyncio.Event()
+    calls: list[tuple[Device, Feature, object]] = []
+
+    async def mock_set_feature(
+        device: Device, feature: Feature, value: object
+    ) -> tuple[CommandResponse, Device]:
+        calls.append((device, feature, value))
+        if feature.name == select_feature_name:
+            first_write_started.set()
+            await allow_first_write_to_finish.wait()
+            return CommandResponse(
+                success=True, message=None, reason=None
+            ), select_updated_device
+        return CommandResponse(success=True, message=None, reason=None), final_device
+
+    mock_client.set_feature = AsyncMock(side_effect=mock_set_feature)
+    coordinator = _build_coordinator(hass, mock_client)
+    coordinator.data = {device_key: initial_device}
+    select_entity = ViClimateSelect(
+        coordinator,
+        device_key,
+        select_feature_name,
+        SelectEntityDescription(key=select_feature_name),
+    )
+    switch_entity = ViClimateSwitch(
+        coordinator,
+        device_key,
+        switch_feature_name,
+        SwitchEntityDescription(key=switch_feature_name),
+    )
+    with (
+        patch.object(select_entity, "async_write_ha_state"),
+        patch.object(switch_entity, "async_write_ha_state"),
+    ):
+        # Act: Start platform actions concurrently while the first write is in flight.
+        select_write = asyncio.create_task(select_entity.async_select_option("heating"))
+        await asyncio.sleep(0)
+        if select_write.done():
+            select_write.result()
+        await first_write_started.wait()
+        switch_write = asyncio.create_task(switch_entity.async_turn_on())
+        await asyncio.sleep(0)
+        allow_first_write_to_finish.set()
+        await asyncio.gather(select_write, switch_write)
+
+        # Assert: The switch action received the device confirmed by the select action.
+        assert calls[1][0] is select_updated_device
+        assert calls[1][1].name == switch_feature_name
+        assert calls[1][2] is True
+        assert coordinator.data[device_key] is final_device
 
 
 @pytest.mark.asyncio

--- a/tests/test_parallelism.py
+++ b/tests/test_parallelism.py
@@ -1,0 +1,26 @@
+"""Tests for Home Assistant platform request parallelism."""
+
+from custom_components.vi_climate_devices import (
+    binary_sensor,
+    climate,
+    number,
+    select,
+    sensor,
+    switch,
+    water_heater,
+)
+
+
+def test_platforms_declare_unlimited_parallel_updates() -> None:
+    """Test every platform delegates request serialization to the coordinator."""
+    platforms = (
+        binary_sensor,
+        climate,
+        number,
+        select,
+        sensor,
+        switch,
+        water_heater,
+    )
+
+    assert all(platform.PARALLEL_UPDATES == 0 for platform in platforms)


### PR DESCRIPTION
Closes #110

## Why

Home Assistant invokes entity updates and actions with per-platform parallelism.
The integration needs to declare that policy explicitly while preserving the
existing coordinator as the single point that serializes API commands and polls.

## What Changed

- Declare `PARALLEL_UPDATES = 0` in every supported entity platform.
- Document that read-only platforms use the coordinator and command platforms
  rely on its central serialization.
- Add regression coverage for cross-platform command serialization and the
  explicit platform declarations.

## Verification

The select/switch concurrency test confirms that a queued switch command uses
the device object returned by the preceding select command. The coordinator
test suite also exercises a poll overlapping a write, ensuring a stale poll
cannot overwrite confirmed command state.
