### PR TITLE
fix: make refresh availability transitions atomic

### DIFF
--- a/custom_components/vi_climate_devices/coordinator.py
+++ b/custom_components/vi_climate_devices/coordinator.py
@@ -45,50 +45,50 @@ class ViClimateDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Device]]):
         self.client = client
         self._known_devices: list[Device] = []
         self._failed_device_keys: set[str] = set()
-        self._device_write_locks: dict[str, asyncio.Lock] = {}
         self._refresh_write_lock = asyncio.Lock()
 
     def is_device_available(self, device_key: str) -> bool:
         """Return whether the most recent refresh succeeded for a device."""
         return device_key not in self._failed_device_keys
 
-    def _log_device_availability(self, device_key: str, error: ViError | None) -> None:
+    def _log_device_availability(
+        self,
+        device_key: str,
+        error: ViError | None,
+        previous_failed_device_keys: set[str],
+    ) -> None:
         """Log a device availability transition once."""
         if error is None:
-            if device_key in self._failed_device_keys:
+            if device_key in previous_failed_device_keys:
                 _LOGGER.info("Device %s is back online", device_key)
-        elif device_key not in self._failed_device_keys:
+        elif device_key not in previous_failed_device_keys:
             _LOGGER.info("Device %s is unavailable: %s", device_key, error)
 
     async def async_set_feature(
         self, device_key: str, feature_name: str, value: object
     ) -> CommandResponse:
-        """Set a feature while serializing writes for the same device."""
+        """Set a feature while serializing writes with refreshes."""
         async with self._refresh_write_lock:
-            write_lock = self._device_write_locks.setdefault(device_key, asyncio.Lock())
-            async with write_lock:
-                device = self.data.get(device_key)
-                if device is None:
-                    raise ValueError(
-                        f"Device {device_key} not found in coordinator data"
-                    )
+            device = self.data.get(device_key)
+            if device is None:
+                raise ValueError(f"Device {device_key} not found in coordinator data")
 
-                feature = device.get_feature(feature_name)
-                if feature is None:
-                    raise ValueError(f"Feature {feature_name} not found in device data")
+            feature = device.get_feature(feature_name)
+            if feature is None:
+                raise ValueError(f"Feature {feature_name} not found in device data")
 
-                response, updated_device = await self.client.set_feature(
-                    device, feature, value
-                )
-                if response.success:
-                    updated_data = dict(self.data)
-                    updated_data[device_key] = updated_device
-                    self._known_devices = list(updated_data.values())
-                    # A command confirms values, not refresh availability. Preserve
-                    # the scheduled poll and the outcome of the last refresh.
-                    self.data = updated_data
-                    self.async_update_listeners()
-                return response
+            response, updated_device = await self.client.set_feature(
+                device, feature, value
+            )
+            if response.success:
+                updated_data = dict(self.data)
+                updated_data[device_key] = updated_device
+                self._known_devices = list(updated_data.values())
+                # A command confirms values, not refresh availability. Preserve
+                # the scheduled poll and the outcome of the last refresh.
+                self.data = updated_data
+                self.async_update_listeners()
+            return response
 
     async def _async_refresh(
         self,
@@ -160,53 +160,46 @@ class ViClimateDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Device]]):
         Raises:
             UpdateFailed: If the update process encounters an unhandled exception.
         """
-        try:
-            # 1. Initial Discovery
-            if not self._known_devices:
-                await self._perform_discovery()
+        # 1. Initial Discovery
+        if not self._known_devices:
+            await self._perform_discovery()
 
-            # 2. Update Loop (Refresh each device)
-            updated_data: dict[str, Device] = {}
-            failed_device_keys: set[str] = set()
+        # 2. Update Loop (Refresh each device)
+        updated_data: dict[str, Device] = {}
+        failed_device_keys: set[str] = set()
+        device_errors: dict[str, ViError] = {}
+        previous_failed_device_keys = self._failed_device_keys
 
-            if self._known_devices:
-                _LOGGER.debug("Updating %s known devices", len(self._known_devices))
-                for device in self._known_devices:
-                    key = f"{device.gateway_serial}_{device.id}"
-                    try:
-                        new_device = await self.client.update_device(device)
-                        updated_data[key] = new_device
-                        self._log_device_availability(key, None)
+        if self._known_devices:
+            _LOGGER.debug("Updating %s known devices", len(self._known_devices))
+            for device in self._known_devices:
+                key = f"{device.gateway_serial}_{device.id}"
+                try:
+                    new_device = await self.client.update_device(device)
+                    updated_data[key] = new_device
 
-                    except OAuth2TokenRequestError:
-                        raise
+                except ViAuthError as err:
+                    # Trigger HA re-auth flow immediately
+                    raise ConfigEntryAuthFailed(
+                        f"Authentication failed for device {device.id}: {err}"
+                    ) from err
 
-                    except ViAuthError as err:
-                        # Trigger HA re-auth flow immediately
-                        raise ConfigEntryAuthFailed(
-                            f"Authentication failed for device {device.id}: {err}"
-                        ) from err
+                except ViError as err:
+                    failed_device_keys.add(key)
+                    device_errors[key] = err
+                    # Keep old data for recovery, but mark its entities unavailable.
+                    updated_data[key] = device
 
-                    except ViError as err:
-                        self._log_device_availability(key, err)
-                        failed_device_keys.add(key)
-                        # Keep old data for recovery, but mark its entities unavailable.
-                        updated_data[key] = device
+            self._failed_device_keys = failed_device_keys
+            for key in updated_data:
+                self._log_device_availability(
+                    key, device_errors.get(key), previous_failed_device_keys
+                )
 
-                self._failed_device_keys = failed_device_keys
-                if failed_device_keys and len(failed_device_keys) == len(updated_data):
-                    raise UpdateFailed("Failed to update all devices")
+            if failed_device_keys and len(failed_device_keys) == len(updated_data):
+                raise UpdateFailed("Failed to update all devices")
 
-                # Update local reference with fresh immutable objects
-                self._known_devices = list(updated_data.values())
+            # Update local reference with fresh immutable objects
+            self._known_devices = list(updated_data.values())
 
-            return updated_data
-
-        except ConfigEntryAuthFailed:
-            raise
-        except OAuth2TokenRequestError:
-            raise
-        except ViAuthError as err:
-            raise ConfigEntryAuthFailed(f"Authentication failed: {err}") from err
-        except ViError as err:
-            raise UpdateFailed(err) from err
+        return updated_data

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -381,6 +381,35 @@ async def test_data_coordinator_propagates_transient_oauth_error(
 
 
 @pytest.mark.asyncio
+async def test_data_coordinator_does_not_log_recovery_before_aborted_refresh_commits(
+    hass: HomeAssistant, mock_client, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Test an OAuth-aborted refresh does not prematurely recover a device."""
+    # Arrange: Device A was unavailable before device B aborts the next refresh.
+    recovered_device = _build_device(device_id="device-0", gateway_serial="gw-main")
+    auth_failed_device = _build_device(device_id="device-1", gateway_serial="gw-backup")
+    token_error = _make_token_error()
+    mock_client.update_device = AsyncMock(side_effect=[recovered_device, token_error])
+    coordinator = _build_coordinator(hass, mock_client)
+    coordinator._known_devices = [recovered_device, auth_failed_device]
+    coordinator._failed_device_keys = {"gw-main_device-0"}
+
+    with (
+        caplog.at_level(
+            logging.INFO, logger="custom_components.vi_climate_devices.coordinator"
+        ),
+        pytest.raises(OAuth2TokenRequestError) as raised_error,
+    ):
+        # Act and assert: Abort before committing the partially refreshed state.
+        await coordinator._async_update_data()
+
+    # Assert: Retain availability and defer the recovery transition log.
+    assert raised_error.value is token_error
+    assert not coordinator.is_device_available("gw-main_device-0")
+    assert [record.getMessage() for record in caplog.records] == []
+
+
+@pytest.mark.asyncio
 async def test_confirmed_write_survives_partial_failure_and_recovery(
     hass: HomeAssistant, mock_client
 ) -> None:


### PR DESCRIPTION
## Summary

- commit device availability transitions only after a complete refresh
- remove redundant per-device write locks while preserving global refresh/write serialization
- simplify refresh exception handling and add OAuth-abort regression coverage

## Testing

- `python scripts/quality_check.py`

Closes #119
