### PR TITLE
docs: clarify contributor guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,72 +29,14 @@ affect the solution.
 
 ## Python and Tests
 
-- Python 3.14+ is the project baseline. Follow the Ruff and Pyright
-  configuration in `pyproject.toml`; do not duplicate their mechanically
-  enforceable rules here.
-- Prefer precise types and built-in generics. Avoid expanding `Any` usage;
-  tighten existing typing incrementally.
-- Use specific exceptions and EAFP where appropriate. Do not catch bare
-  `Exception` or leak HTTP-layer exceptions into integration logic.
-- Use descriptive identifiers. Avoid single-letter local variables except for
-  conventional, short-lived uses; name booleans with `is_`, `has_`, or
-  `should_`. Sort collections when their order has no semantic meaning.
-- Use `pathlib.Path` for filesystem paths. Keep log messages free of trailing
-  periods.
-- Start every Python file, including test files, with a concise module docstring
-  describing its purpose.
-- Use Google-style docstrings for public classes, functions, and methods.
-  Describe their purpose and externally observable behavior. Explain design
-  rationale or constraints when they are not apparent from the code. Do not
-  repeat parameter or return types already present in annotations.
-- Include a `Raises:` section for exceptions that are intentionally raised,
-  translated, or form a relevant part of the callable's public contract. Do
-  not list incidental implementation exceptions that callers cannot reasonably
-  handle. Test functions do not require docstrings when their name and
-  Arrange-Act-Assert structure describe the scenario clearly.
-- Keep comments meaningful and scenario-specific. Explain non-obvious reasons
-  and constraints; omit code paraphrases, agent reasoning notes, and abandoned
-  implementation plans.
-- Use pytest functions and the Home Assistant test stack. Prefer
-  `MockViClient` with the `Vitocal250A` fixture; do not mock HTTP requests in
-  this integration. Use `MockConfigEntry` when setting up an integration.
-- Structure every test according to Arrange-Act-Assert. Add explicit,
-  test-specific `# Arrange:`, `# Act:`, and `# Assert:` comments when the test
-  is long enough that its phases are not immediately apparent, or when it has
-  multiple phases, state transitions, concurrent operations, or substantial
-  fixture and mock setup. Do not add comments that merely restate obvious code.
-  Use native `assert` statements for values and state, mock assertion helpers
-  for interactions, and `pytest.raises` for expected exceptions.
-  Exception-focused tests may use `# Act and assert: ...` when separating the
-  phases would be artificial. In multi-step scenarios, label each additional
-  phase explicitly; do not place new mock setup or actions under an Assert
-  comment.
-- Use snapshots for discovery and diagnostics coverage; inspect every `.ambr`
-  diff rather than accepting it blindly.
-- When snapshots or `pytest-homeassistant-custom-component` change, a green
-  Linux CI run is required in addition to local validation.
+For Python implementation, test, or review work, read
+[CONTRIBUTING.md](CONTRIBUTING.md) before starting.
 
 ## Local Quality Gate
 
-Set up a development environment with:
-
-```bash
-python3.14 -m venv .venv
-source .venv/bin/activate
-python -m pip install --upgrade pip
-python -m pip install '.[dev]'
-pre-commit install --install-hooks
-```
-
-Run the complete gate before proposing a commit or push:
-
-```bash
-python scripts/quality_check.py
-```
-
-The installed pre-commit hook and GitHub CI run the same gate. If dependencies,
-snapshots, packaging, or CI configuration change, also validate once in a fresh
-`.[dev]` environment.
+Before proposing a commit or push, run the complete quality gate. For
+development setup and commands, read the [Development](README.md#development)
+section in `README.md`.
 
 ## Git, Pull Requests, and Releases
 
@@ -116,9 +58,10 @@ snapshots, packaging, or CI configuration change, also validate once in a fresh
 ## Documentation Drift
 
 After changes to architecture, dependencies, setup, tests, CI, GitHub policy,
-or releases, check `README.md`, this file, `pyproject.toml`, and relevant
-`.github/workflows/` files. Update affected documentation in the same change,
-or explicitly state that no update was needed.
+or releases, check `README.md`, `CONTRIBUTING.md`, `AGENTS.md`,
+`pyproject.toml`, and relevant `.github/workflows/` files. Update affected
+documentation in the same change, or explicitly state that no update was
+needed.
 
 ## Agent skills
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,54 @@
+# Contributing
+
+## Python
+
+- Python 3.14+ is the project baseline. Follow the Ruff and Pyright
+  configuration in `pyproject.toml`; do not duplicate their mechanically
+  enforceable rules here.
+- Prefer precise types and built-in generics. Avoid expanding `Any` usage;
+  tighten existing typing incrementally.
+- Use specific exceptions and EAFP where appropriate. Do not catch bare
+  `Exception` or leak HTTP-layer exceptions into integration logic.
+- Use descriptive identifiers. Avoid single-letter local variables except for
+  conventional, short-lived uses; name booleans with `is_`, `has_`, or
+  `should_`. Sort collections when their order has no semantic meaning.
+- Use `pathlib.Path` for filesystem paths. Keep log messages free of trailing
+  periods.
+- Start every Python file, including test files, with a concise module docstring
+  describing its purpose.
+## Documentation and Comments
+
+- Use Google-style docstrings for public classes, functions, and methods.
+  Describe their purpose and externally observable behavior. Explain design
+  rationale or constraints when they are not apparent from the code. Do not
+  repeat parameter or return types already present in annotations.
+- Include a `Raises:` section for exceptions that are intentionally raised,
+  translated, or form a relevant part of the callable's public contract. Do
+  not list incidental implementation exceptions that callers cannot reasonably
+  handle. Test functions do not require docstrings when their name and
+  Arrange-Act-Assert structure describe the scenario clearly.
+- Keep comments meaningful and scenario-specific. Explain non-obvious reasons
+  and constraints; omit code paraphrases, agent reasoning notes, and abandoned
+  implementation plans.
+## Tests
+
+- Use pytest functions and the Home Assistant test stack. Prefer
+  `MockViClient` with the `Vitocal250A` fixture; do not mock HTTP requests in
+  this integration. Use `MockConfigEntry` when setting up an integration.
+- Structure every test according to Arrange-Act-Assert. Add explicit,
+  test-specific `# Arrange:`, `# Act:`, and `# Assert:` comments when the test
+  is long enough that its phases are not immediately apparent, or when it has
+  multiple phases, state transitions, concurrent operations, or substantial
+  fixture and mock setup. Do not add comments that merely restate obvious code.
+  Use native `assert` statements for values and state, mock assertion helpers
+  for interactions, and `pytest.raises` for expected exceptions.
+  Exception-focused tests may use `# Act and assert: ...` when separating the
+  phases would be artificial. In multi-step scenarios, label each additional
+  phase explicitly; do not place new mock setup or actions under an Assert
+  comment.
+## Snapshots and CI
+
+- Use snapshots for discovery and diagnostics coverage; inspect every `.ambr`
+  diff rather than accepting it blindly.
+- When snapshots or `pytest-homeassistant-custom-component` change, a green
+  Linux CI run is required in addition to local validation.

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ logger:
 
 ## Development
 
-### Running Tests
+### Development Setup
 
 ```bash
 python3.14 -m venv .venv
@@ -149,6 +149,11 @@ python scripts/quality_check.py
 # Run the same gate manually through pre-commit.
 pre-commit run --all-files
 ```
+
+### Contributor Guidance
+
+For Python and test standards, read [CONTRIBUTING.md](CONTRIBUTING.md).
+Automated coding agents must also follow [AGENTS.md](AGENTS.md).
 
 ---
 


### PR DESCRIPTION
## Why

Contributor guidance was split between documents without a clear ownership
model. Contributors and coding agents need a predictable place for each kind
of information while avoiding duplicated development commands.

## What Changed

- Added `CONTRIBUTING.md` as the single source of Python and test standards.
- Kept repository-specific agent constraints in `AGENTS.md` and added focused
  pointers to the contribution standards and development commands.
- Positioned `README.md` as the human-facing development entry point and
  linked all contributor guidance.
