### PR TITLE
fix: preserve application credential names

### DIFF
--- a/custom_components/vi_climate_devices/application_credentials.py
+++ b/custom_components/vi_climate_devices/application_credentials.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import override
+
 from homeassistant.components.application_credentials import (
     AuthorizationServer,
     ClientCredential,
@@ -12,6 +14,32 @@ from homeassistant.helpers.config_entry_oauth2_flow import (
     LocalOAuth2ImplementationWithPkce,
 )
 from vi_api_client.const import ENDPOINT_AUTHORIZE, ENDPOINT_TOKEN
+
+
+class _OAuth2Implementation(LocalOAuth2ImplementationWithPkce):
+    """Viessmann PKCE implementation with its application credential name."""
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        auth_domain: str,
+        credential: ClientCredential,
+    ) -> None:
+        """Initialize the OAuth implementation."""
+        super().__init__(
+            hass,
+            auth_domain,
+            credential.client_id,
+            authorize_url=ENDPOINT_AUTHORIZE,
+            token_url=ENDPOINT_TOKEN,
+        )
+        self._name = credential.name
+
+    @property
+    @override
+    def name(self) -> str:
+        """Return the application credential name."""
+        return self._name or self.client_id
 
 
 async def async_get_authorization_server(hass: HomeAssistant) -> AuthorizationServer:
@@ -26,10 +54,8 @@ async def async_get_auth_implementation(
     hass: HomeAssistant, auth_domain: str, credential: ClientCredential
 ) -> AbstractOAuth2Implementation:
     """Return auth implementation for a custom auth implementation."""
-    return LocalOAuth2ImplementationWithPkce(
+    return _OAuth2Implementation(
         hass,
         auth_domain,
-        credential.client_id,
-        authorize_url=ENDPOINT_AUTHORIZE,
-        token_url=ENDPOINT_TOKEN,
+        credential,
     )

--- a/tests/test_application_credentials.py
+++ b/tests/test_application_credentials.py
@@ -52,10 +52,33 @@ async def test_async_get_auth_implementation_returns_pkce_implementation(
 
     # Assert: The integration uses a PKCE-capable local OAuth implementation.
     assert isinstance(implementation, LocalOAuth2ImplementationWithPkce)
+    assert implementation.name == "Viessmann"
     assert implementation.client_id == "client-id"
     assert implementation.client_secret == ""
     assert implementation.authorize_url == ENDPOINT_AUTHORIZE
     assert implementation.token_url == ENDPOINT_TOKEN
+
+
+@pytest.mark.asyncio
+async def test_async_get_auth_implementation_falls_back_to_client_id(
+    hass: HomeAssistant,
+) -> None:
+    """Test unnamed application credentials use their client ID as the name."""
+    # Arrange: Provide stored credentials without a user-defined name.
+    credential = ClientCredential(
+        client_id="client-id",
+        client_secret="client-secret",
+    )
+
+    # Act: Create the OAuth implementation from the unnamed credentials.
+    implementation = await async_get_auth_implementation(
+        hass,
+        "vi_climate_devices",
+        credential,
+    )
+
+    # Assert: The client ID remains available as a meaningful fallback name.
+    assert implementation.name == "client-id"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Why

Home Assistant stores a user-defined name for each application credential, but the PKCE implementation returned by this integration inherited the generic name "Local application credentials". As a result, the OAuth implementation picker and newly created config entries could not display the stored credential name, such as "Viessmann".

Closes #124.

## What Changed

- Extend `LocalOAuth2ImplementationWithPkce` with an integration-owned implementation that exposes `ClientCredential.name`.
- Fall back to the credential client ID when no name is stored.
- Preserve the existing Viessmann endpoints, public-client behavior, and fresh PKCE verifier behavior.
- Add regression coverage for both named and unnamed application credentials.

## Verification

Before the fix, the regression tests returned "Local application credentials" for both named and unnamed credentials. After the fix, they return "Viessmann" and the client ID respectively.
