### PR TITLE
Fix climate target temperature capability

### DIFF
--- a/custom_components/vi_climate_devices/climate.py
+++ b/custom_components/vi_climate_devices/climate.py
@@ -123,7 +123,7 @@ class ViClimate(ViClimateEntity, ClimateEntity):
 
     _attr_temperature_unit = UnitOfTemperature.CELSIUS
     _attr_translation_key = "heating_circuit"
-    _attr_supported_features = ClimateEntityFeature.TARGET_TEMPERATURE
+    _attr_supported_features = ClimateEntityFeature(0)
 
     def __init__(
         self,
@@ -342,16 +342,33 @@ class ViClimate(ViClimateEntity, ClimateEntity):
         return None
 
     def _get_active_temp_feature(self) -> Feature | None:
-        """Get the temperature feature corresponding to the active operating program."""
+        """Get the writable temperature feature for the active operating program."""
         active_program_feature = self._get_feature(
             f"heating.circuits.{self._circuit_index}.operating.programs.active"
         )
         if not active_program_feature or not active_program_feature.value:
             return None
 
-        return self._get_program_temperature_feature(str(active_program_feature.value))
+        temp_feature = self._get_program_temperature_feature(
+            str(active_program_feature.value)
+        )
+        if (
+            not temp_feature
+            or not temp_feature.is_enabled
+            or not temp_feature.is_writable
+        ):
+            return None
+        return temp_feature
 
     # --- Properties ---
+
+    @property
+    def supported_features(self) -> ClimateEntityFeature:
+        """Return capabilities available for the current operating program."""
+        supported_features = self._attr_supported_features
+        if self._get_active_temp_feature():
+            supported_features |= ClimateEntityFeature.TARGET_TEMPERATURE
+        return supported_features
 
     @property
     def current_temperature(self) -> float | None:
@@ -522,19 +539,9 @@ class ViClimate(ViClimateEntity, ClimateEntity):
         if value is None:
             return
 
-        active_program_feature = self._get_feature(
-            f"heating.circuits.{self._circuit_index}.operating.programs.active"
-        )
-        if not active_program_feature or not active_program_feature.value:
-            raise HomeAssistantError("Could not determine the active program")
-
-        program_name = str(active_program_feature.value)
-        temp_feature = self._get_program_temperature_feature(program_name)
+        temp_feature = self._get_active_temp_feature()
         if not temp_feature:
-            raise HomeAssistantError(
-                "No temperature control feature found for the active program: "
-                f"{program_name}"
-            )
+            raise HomeAssistantError("Target-temperature control is not available")
 
         # 1. OPTIMISTIC UPDATE
         self._optimistic_temp = value

--- a/tests/test_climate.py
+++ b/tests/test_climate.py
@@ -404,6 +404,7 @@ async def test_climate_rejects_target_temperature_in_standby(
     hass: HomeAssistant,
 ) -> None:
     """Test standby circuits do not advertise target-temperature control."""
+    # Arrange: Set up the integration with the standby Vitocal333G fixture.
     client = MockViClient(device_name="Vitocal333G-with-Vitovent300F", auth=None)
     client.set_feature = AsyncMock(wraps=client.set_feature)
     entry = MockConfigEntry(domain=DOMAIN, data={"client_id": "123", "token": "abc"})
@@ -424,6 +425,7 @@ async def test_climate_rejects_target_temperature_in_standby(
         ),
         patch("custom_components.vi_climate_devices.HAAuth"),
     ):
+        # Act: Load the integration and retrieve the first heating circuit.
         await hass.config_entries.async_setup(entry.entry_id)
         await hass.async_block_till_done()
 
@@ -432,6 +434,8 @@ async def test_climate_rejects_target_temperature_in_standby(
             for state in hass.states.async_all("climate")
             if state.entity_id.endswith("heating_circuit_0")
         )
+
+        # Assert: Keep reporting HVAC state but reject temperature control in HA.
         assert state.state == HVACMode.HEAT
         assert not (
             state.attributes["supported_features"]
@@ -462,6 +466,7 @@ async def test_climate_requires_writable_active_program_temperature(
     temperature_feature_state: str,
 ) -> None:
     """Test unavailable program temperatures do not disable the climate entity."""
+    # Arrange: Remove one requirement from the active program temperature feature.
     device = (await mock_client.get_full_installation_status("99999"))[0]
     temperature_feature_name = (
         "heating.circuits.0.operating.programs.normalHeating.temperature"
@@ -482,9 +487,15 @@ async def test_climate_requires_writable_active_program_temperature(
     coordinator.async_set_feature = AsyncMock()
     entity = ViClimate(coordinator, map_key, "0")
 
-    assert entity.hvac_mode == HVACMode.HEAT
-    assert not (entity.supported_features & ClimateEntityFeature.TARGET_TEMPERATURE)
-    assert entity.target_temperature is None
+    # Act: Resolve the entity's state and advertised capabilities.
+    hvac_mode = entity.hvac_mode
+    supported_features = entity.supported_features
+    target_temperature = entity.target_temperature
+
+    # Assert: Keep HVAC state but neither expose nor accept target-temperature control.
+    assert hvac_mode == HVACMode.HEAT
+    assert not (supported_features & ClimateEntityFeature.TARGET_TEMPERATURE)
+    assert target_temperature is None
 
     with pytest.raises(
         HomeAssistantError,

--- a/tests/test_climate.py
+++ b/tests/test_climate.py
@@ -12,6 +12,7 @@ from homeassistant.components.climate.const import (
     SERVICE_SET_HVAC_MODE,
     SERVICE_SET_PRESET_MODE,
     SERVICE_SET_TEMPERATURE,
+    ClimateEntityFeature,
     HVACAction,
     HVACMode,
 )
@@ -296,6 +297,10 @@ async def test_climate_creation_and_services(  # noqa: PLR0915
         # Target Temp: 20.0 (from normalHeating program temperature).
         # Min Temp: 3.0, Max Temp: 37.0, Step: 1.0 (from normalHeating program control).
         assert state.state == HVACMode.HEAT
+        assert (
+            state.attributes["supported_features"]
+            & ClimateEntityFeature.TARGET_TEMPERATURE
+        )
         assert float(state.attributes["temperature"]) == 20.0
         assert state.attributes["min_temp"] == 3.0
         assert state.attributes["max_temp"] == 37.0
@@ -392,6 +397,102 @@ async def test_climate_creation_and_services(  # noqa: PLR0915
 
         await hass.config_entries.async_unload(entry.entry_id)
         await hass.async_block_till_done()
+
+
+@pytest.mark.asyncio
+async def test_climate_rejects_target_temperature_in_standby(
+    hass: HomeAssistant,
+) -> None:
+    """Test standby circuits do not advertise target-temperature control."""
+    client = MockViClient(device_name="Vitocal333G-with-Vitovent300F", auth=None)
+    client.set_feature = AsyncMock(wraps=client.set_feature)
+    entry = MockConfigEntry(domain=DOMAIN, data={"client_id": "123", "token": "abc"})
+    entry.add_to_hass(hass)
+
+    with (
+        patch(
+            "custom_components.vi_climate_devices.ViessmannClient",
+            return_value=client,
+        ),
+        patch(
+            "homeassistant.helpers.config_entry_oauth2_flow.async_get_config_entry_implementation",
+            return_value=MagicMock(),
+        ),
+        patch(
+            "homeassistant.helpers.config_entry_oauth2_flow.OAuth2Session.async_ensure_token_valid",
+            return_value=None,
+        ),
+        patch("custom_components.vi_climate_devices.HAAuth"),
+    ):
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+        state = next(
+            state
+            for state in hass.states.async_all("climate")
+            if state.entity_id.endswith("heating_circuit_0")
+        )
+        assert state.state == HVACMode.HEAT
+        assert not (
+            state.attributes["supported_features"]
+            & ClimateEntityFeature.TARGET_TEMPERATURE
+        )
+
+        with pytest.raises(
+            HomeAssistantError,
+            match=r"does not support action climate\.set_temperature",
+        ):
+            await hass.services.async_call(
+                "climate",
+                SERVICE_SET_TEMPERATURE,
+                {"entity_id": state.entity_id, "temperature": 20.0},
+                blocking=True,
+            )
+
+        client.set_feature.assert_not_called()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "temperature_feature_state",
+    ["missing", "disabled", "read-only"],
+)
+async def test_climate_requires_writable_active_program_temperature(
+    mock_client: MockViClient,
+    temperature_feature_state: str,
+) -> None:
+    """Test unavailable program temperatures do not disable the climate entity."""
+    device = (await mock_client.get_full_installation_status("99999"))[0]
+    temperature_feature_name = (
+        "heating.circuits.0.operating.programs.normalHeating.temperature"
+    )
+    features = []
+    for feature in device.features:
+        if feature.name != temperature_feature_name:
+            features.append(feature)
+        elif temperature_feature_state == "disabled":
+            features.append(replace(feature, is_enabled=False))
+        elif temperature_feature_state == "read-only":
+            features.append(replace(feature, control=None))
+
+    device = replace(device, features=features)
+    map_key = f"{device.gateway_serial}_{device.id}"
+    coordinator = MagicMock()
+    coordinator.data = {map_key: device}
+    coordinator.async_set_feature = AsyncMock()
+    entity = ViClimate(coordinator, map_key, "0")
+
+    assert entity.hvac_mode == HVACMode.HEAT
+    assert not (entity.supported_features & ClimateEntityFeature.TARGET_TEMPERATURE)
+    assert entity.target_temperature is None
+
+    with pytest.raises(
+        HomeAssistantError,
+        match="Target-temperature control is not available",
+    ):
+        await entity.async_set_temperature(temperature=21.0)
+
+    coordinator.async_set_feature.assert_not_awaited()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- expose target-temperature control only when the active program temperature feature is enabled and writable
- use the same capability check in the temperature action path
- keep climate entities and HVAC mode reporting available when temperature control is unavailable
- cover writable, standby, missing, disabled, and read-only features, including the Vitocal333G fixture

## Existing-user impact

- unavailable target-temperature controls disappear immediately without a deprecation period
- automations calling climate.set_temperature in these states now fail through normal Home Assistant capability validation instead of reaching a guaranteed API failure
- writable active programs remain unchanged

## Validation

- full local quality gate passed
- 103 tests passed
- 1 snapshot passed
- Pyright: 0 errors
- Ruff and formatting passed

Closes #128