### PR TITLE
fix(number): skip read-only number controls

### DIFF
--- a/custom_components/vi_climate_devices/number.py
+++ b/custom_components/vi_climate_devices/number.py
@@ -196,15 +196,20 @@ async def async_setup_entry(
                 if is_feature_ignored(feature.name, IGNORED_FEATURES):
                     continue
 
+                # Numbers need a writable feature and bounded control.
+                if (
+                    not feature.is_writable
+                    or not feature.control
+                    or (feature.control.min is None and feature.control.max is None)
+                ):
+                    continue
+
                 # 1. Defined Entities
                 if feature.name in NUMBER_TYPES:
                     desc = NUMBER_TYPES[feature.name]
                     entities.append(
                         ViClimateNumber(coordinator, map_key, feature.name, desc)
                     )
-                    continue
-
-                if not feature.is_writable:
                     continue
 
                 # 2. Configured Templates
@@ -223,25 +228,22 @@ async def async_setup_entry(
 
                 # Automatic Discovery (Fallback)
                 # Control must exist and have min/max constraints
-                if feature.control and (
-                    feature.control.min is not None or feature.control.max is not None
-                ):
-                    description = NumberEntityDescription(
-                        key=feature.name,
-                        name=beautify_name(feature.name),
-                        entity_category=EntityCategory.CONFIG,
+                description = NumberEntityDescription(
+                    key=feature.name,
+                    name=beautify_name(feature.name),
+                    entity_category=EntityCategory.CONFIG,
+                )
+                # Only disable entities by default for thoroughly tested devices
+                is_tested = device.model_id in TESTED_DEVICES
+                entities.append(
+                    ViClimateNumber(
+                        coordinator,
+                        map_key,
+                        feature.name,
+                        description,
+                        enabled_default=not is_tested,
                     )
-                    # Only disable entities by default for thoroughly tested devices
-                    is_tested = device.model_id in TESTED_DEVICES
-                    entities.append(
-                        ViClimateNumber(
-                            coordinator,
-                            map_key,
-                            feature.name,
-                            description,
-                            enabled_default=not is_tested,
-                        )
-                    )
+                )
 
     async_add_entities(entities)
 

--- a/tests/test_number.py
+++ b/tests/test_number.py
@@ -14,9 +14,69 @@ from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import entity_registry as er
 from homeassistant.util.unit_system import US_CUSTOMARY_SYSTEM
 from pytest_homeassistant_custom_component.common import MockConfigEntry
+from vi_api_client.mock_client import MockViClient
 from vi_api_client.models import CommandResponse
 
 from custom_components.vi_climate_devices.const import DOMAIN
+
+
+@pytest.mark.asyncio
+async def test_read_only_known_number_is_exposed_as_sensor(
+    hass: HomeAssistant,
+) -> None:
+    """Test known read-only controls remain sensors without Number services."""
+    # Arrange: Load the fixture where the known switch-off value is read-only.
+    client = MockViClient(device_name="Vitocal333G-with-Vitovent300F", auth=None)
+    client.set_feature = AsyncMock(wraps=client.set_feature)
+    entry = MockConfigEntry(domain=DOMAIN, data={"client_id": "123", "token": "abc"})
+    entry.add_to_hass(hass)
+
+    with (
+        patch(
+            "custom_components.vi_climate_devices.ViessmannClient",
+            return_value=client,
+        ),
+        patch(
+            "homeassistant.helpers.config_entry_oauth2_flow.async_get_config_entry_implementation",
+            return_value=MagicMock(),
+        ),
+        patch(
+            "homeassistant.helpers.config_entry_oauth2_flow.OAuth2Session.async_ensure_token_valid",
+            return_value=None,
+        ),
+        patch("custom_components.vi_climate_devices.HAAuth"),
+    ):
+        # Act: Initialize the integration.
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+        # Assert: The read-only feature has no Number entity or service target.
+        number_entity_id = (
+            "number.vitocal333g_with_vitovent300f_dhw_hysteresis_switch_off"
+        )
+        assert hass.states.get(number_entity_id) is None
+
+        # Act: Try to set the missing Number entity.
+        await hass.services.async_call(
+            "number",
+            SERVICE_SET_VALUE,
+            {"entity_id": number_entity_id, "value": 6.0},
+            blocking=True,
+        )
+
+        # Assert: No write request reaches the client.
+        client.set_feature.assert_not_awaited()
+
+        # Assert: The value remains exposed through sensor discovery.
+        sensor = hass.states.get(
+            "sensor.vitocal333g_with_vitovent300f_dhw_temperature_hysteresis_"
+            "switch_off_value"
+        )
+        assert sensor is not None
+        assert sensor.state == "5"
+
+        await hass.config_entries.async_unload(entry.entry_id)
+        await hass.async_block_till_done()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- require writable, bounded controls for every Number mapping
- retain read-only values through sensor discovery
- cover the Vitocal333G read-only hysteresis switch-off feature

## Validation
- `.venv/bin/python scripts/quality_check.py`

Fixes #132