### PR TITLE
fix(water-heater): map modes by device family

### DIFF
--- a/custom_components/vi_climate_devices/water_heater.py
+++ b/custom_components/vi_climate_devices/water_heater.py
@@ -35,8 +35,8 @@ FEATURE_TARGET_TEMP = "heating.dhw.temperature.main"
 FEATURE_CURRENT_TEMP = "heating.dhw.sensors.temperature.hotWaterStorage"
 FEATURE_MODE = "heating.dhw.operating.modes.active"
 
-# Mapping from Viessmann API modes to Home Assistant standard states
-# This ensures proper UI translation.
+# Mapping from Viessmann API modes to Home Assistant standard states.
+# The ``balanced`` API mode is device-family-specific and is handled separately.
 VIESSMANN_TO_HA_MODE = {
     "off": STATE_OFF,
     "standby": STATE_OFF,
@@ -44,18 +44,20 @@ VIESSMANN_TO_HA_MODE = {
     "efficient": STATE_ECO,
     "efficientWithMinComfort": STATE_PERFORMANCE,
     "comfort": STATE_PERFORMANCE,
-    "balanced": STATE_HEAT_PUMP,
     "standard": STATE_GAS,
 }
 
-# Reverse mapping: HA state -> list of possible Viessmann modes (in preference order)
-# We'll pick the first one that's actually available on the device
+# Reverse mapping for device-independent modes. The first available mode wins.
 HA_TO_VIESSMANN_MODES = {
     STATE_OFF: ["off", "standby"],
     STATE_ECO: ["eco", "efficient"],
     STATE_PERFORMANCE: ["comfort", "efficientWithMinComfort"],
-    STATE_HEAT_PUMP: ["balanced"],
     STATE_GAS: ["standard"],
+}
+
+DEVICE_FAMILY_MODE_MAPPINGS = {
+    "vitocal": {"balanced": STATE_HEAT_PUMP},
+    "vitodens": {"balanced": STATE_GAS},
 }
 
 
@@ -150,6 +152,33 @@ class ViClimateWaterHeater(ViClimateEntity, WaterHeaterEntity):
             if feature.control.step is not None:
                 self._attr_target_temperature_step = feature.control.step
 
+    def _get_device_family_mode_mapping(self) -> dict[str, str] | None:
+        """Return the current device family's API-to-HA mode mapping."""
+        device = self.coordinator.data.get(self._map_key)
+        if device:
+            model_id = device.model_id.lower()
+            for family, family_modes in DEVICE_FAMILY_MODE_MAPPINGS.items():
+                if model_id.startswith(family):
+                    return family_modes
+        return None
+
+    def _map_api_mode_to_ha_mode(self, api_mode: str) -> str | None:
+        """Map an API mode to the device family's HA operation mode."""
+        if family_modes := self._get_device_family_mode_mapping():
+            return family_modes.get(api_mode) or VIESSMANN_TO_HA_MODE.get(api_mode)
+        return VIESSMANN_TO_HA_MODE.get(api_mode)
+
+    def _get_api_mode_candidates(self, operation_mode: str) -> list[str]:
+        """Return API modes that represent an HA operation on this device."""
+        if family_modes := self._get_device_family_mode_mapping():
+            family_candidates = [
+                api_mode
+                for api_mode, ha_mode in family_modes.items()
+                if ha_mode == operation_mode
+            ]
+            return family_candidates + HA_TO_VIESSMANN_MODES.get(operation_mode, [])
+        return HA_TO_VIESSMANN_MODES.get(operation_mode, [])
+
     @property
     def suggested_display_precision(self) -> int | None:
         """Return the suggested number of decimal places."""
@@ -196,9 +225,7 @@ class ViClimateWaterHeater(ViClimateEntity, WaterHeaterEntity):
             return self._optimistic_mode
         feat = self._get_feature(FEATURE_MODE)
         if feat and feat.value:
-            # Map Viessmann mode to HA standard state
-            val = str(feat.value)
-            return VIESSMANN_TO_HA_MODE.get(val, val)
+            return self._map_api_mode_to_ha_mode(str(feat.value))
         return None
 
     @property
@@ -220,10 +247,11 @@ class ViClimateWaterHeater(ViClimateEntity, WaterHeaterEntity):
         # Convert to HA standard states (deduplicated)
         ha_modes = set()
         for api_mode in api_modes:
-            ha_mode = VIESSMANN_TO_HA_MODE.get(api_mode, api_mode)
-            ha_modes.add(ha_mode)
+            ha_mode = self._map_api_mode_to_ha_mode(api_mode)
+            if ha_mode:
+                ha_modes.add(ha_mode)
 
-        return list(ha_modes)
+        return sorted(ha_modes)
 
     # --- Actions ---
 
@@ -277,7 +305,7 @@ class ViClimateWaterHeater(ViClimateEntity, WaterHeaterEntity):
 
         # Convert HA standard state to Viessmann API mode
         # Find first candidate that's actually available on device
-        candidates = HA_TO_VIESSMANN_MODES.get(operation_mode, [operation_mode])
+        candidates = self._get_api_mode_candidates(operation_mode)
         viessmann_mode = None
         for candidate in candidates:
             if candidate in available_api_modes:

--- a/tests/test_water_heater.py
+++ b/tests/test_water_heater.py
@@ -1,5 +1,6 @@
 """Tests for ViClimate water heater entities."""
 
+from dataclasses import replace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -7,19 +8,132 @@ from homeassistant.components.water_heater import (
     SERVICE_SET_OPERATION_MODE,
     SERVICE_SET_TEMPERATURE,
     STATE_ECO,
+    STATE_GAS,
+    STATE_HEAT_PUMP,
     STATE_PERFORMANCE,
     WaterHeaterEntityFeature,
 )
+from homeassistant.const import STATE_OFF
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from pytest_homeassistant_custom_component.common import MockConfigEntry
+from vi_api_client.mock_client import MockViClient
 from vi_api_client.models import CommandResponse, Device, Feature
 
 from custom_components.vi_climate_devices.const import DOMAIN
 from custom_components.vi_climate_devices.water_heater import (
     FEATURE_MODE,
     FEATURE_TARGET_TEMP,
+    ViClimateWaterHeater,
 )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("device_name", "api_mode", "api_modes", "ha_mode", "expected_api_mode"),
+    [
+        pytest.param(
+            "Vitodens200W",
+            "balanced",
+            ["balanced", "off"],
+            STATE_GAS,
+            "balanced",
+            id="vitodens-balanced-is-gas",
+        ),
+        pytest.param(
+            "Vitodens200W",
+            "standard",
+            ["standard", "off"],
+            STATE_GAS,
+            "standard",
+            id="vitodens-standard-is-gas",
+        ),
+        pytest.param(
+            "Vitocal250A",
+            "balanced",
+            ["balanced", "off"],
+            STATE_HEAT_PUMP,
+            "balanced",
+            id="vitocal-balanced-is-heat-pump",
+        ),
+    ],
+)
+async def test_water_heater_maps_device_family_operation_modes(
+    device_name: str,
+    api_mode: str,
+    api_modes: list[str],
+    ha_mode: str,
+    expected_api_mode: str,
+) -> None:
+    """Expose and set device-family-specific water-heater operations."""
+    # Arrange: Create a device with the requested DHW mode configuration.
+    client = MockViClient(device_name=device_name)
+    fixture_device = (await client.get_full_installation_status("99999"))[0]
+    mode_feature = fixture_device.get_feature(FEATURE_MODE)
+    assert mode_feature is not None
+    assert mode_feature.control is not None
+    configured_mode_feature = replace(
+        mode_feature,
+        value=api_mode,
+        control=replace(mode_feature.control, options=api_modes),
+    )
+    device = replace(
+        fixture_device,
+        features=[
+            configured_mode_feature if feature.name == FEATURE_MODE else feature
+            for feature in fixture_device.features
+        ],
+    )
+    coordinator = MagicMock()
+    coordinator.data = {"device": device}
+    coordinator.async_set_feature = AsyncMock(
+        return_value=CommandResponse(success=True)
+    )
+    target_feature = device.get_feature(FEATURE_TARGET_TEMP)
+    assert target_feature is not None
+    entity = ViClimateWaterHeater(coordinator, "device", target_feature)
+
+    # Act and assert: Report only the standard HA operation and translate it back.
+    assert entity.current_operation == ha_mode
+    assert entity.operation_list == [ha_mode, STATE_OFF]
+    with patch.object(entity, "async_write_ha_state"):
+        await entity.async_set_operation_mode(ha_mode)
+
+    coordinator.async_set_feature.assert_awaited_once_with(
+        "device", FEATURE_MODE, expected_api_mode
+    )
+
+
+@pytest.mark.asyncio
+async def test_water_heater_omits_unknown_api_operation_modes() -> None:
+    """Do not expose unknown API modes as Home Assistant operations."""
+    # Arrange: Create a Vitocal device reporting an unsupported mode.
+    client = MockViClient(device_name="Vitocal250A")
+    fixture_device = (await client.get_full_installation_status("99999"))[0]
+    mode_feature = fixture_device.get_feature(FEATURE_MODE)
+    assert mode_feature is not None
+    assert mode_feature.control is not None
+    unknown_mode_feature = replace(
+        mode_feature,
+        value="unknownMode",
+        control=replace(mode_feature.control, options=["unknownMode"]),
+    )
+    device = replace(
+        fixture_device,
+        features=[
+            unknown_mode_feature if feature.name == FEATURE_MODE else feature
+            for feature in fixture_device.features
+        ],
+    )
+    coordinator = MagicMock()
+    coordinator.data = {"device": device}
+    target_feature = device.get_feature(FEATURE_TARGET_TEMP)
+    assert target_feature is not None
+    entity = ViClimateWaterHeater(coordinator, "device", target_feature)
+
+    # Act and assert: Do not pass unknown vendor values to Home Assistant.
+    assert entity.current_operation is None
+    assert entity.operation_list == []
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- map DHW balanced mode to the correct Home Assistant operation for Vitodens and Vitocal devices
- use the same device-aware mapping for service writes, including supported-mode fallback
- cover both device families and unknown API modes

## Validation
- python scripts/quality_check.py

Closes #133