### PR TITLE
Fix auto-discovered energy statistics

### DIFF
--- a/custom_components/vi_climate_devices/sensor.py
+++ b/custom_components/vi_climate_devices/sensor.py
@@ -37,6 +37,28 @@ _LOGGER = logging.getLogger(__name__)
 
 PARALLEL_UPDATES = 0
 
+AUTO_DISCOVERED_TOTAL_INCREASING_ENERGY_FEATURES = frozenset(
+    {
+        "ess.transfer.charge.cumulated.currentDay",
+        "ess.transfer.charge.cumulated.currentWeek",
+        "ess.transfer.charge.cumulated.currentMonth",
+        "ess.transfer.charge.cumulated.currentYear",
+        "ess.transfer.charge.cumulated.lifeCycle",
+        "ess.transfer.discharge.cumulated.currentDay",
+        "ess.transfer.discharge.cumulated.currentWeek",
+        "ess.transfer.discharge.cumulated.currentMonth",
+        "ess.transfer.discharge.cumulated.currentYear",
+        "ess.transfer.discharge.cumulated.lifeCycle",
+        "photovoltaic.production.cumulated.currentDay",
+        "photovoltaic.production.cumulated.currentWeek",
+        "photovoltaic.production.cumulated.currentMonth",
+        "photovoltaic.production.cumulated.currentYear",
+        "photovoltaic.production.cumulated.lifeCycle",
+        "pcc.transfer.consumption.total",
+        "pcc.transfer.feedIn.total",
+    }
+)
+
 
 # Templates with regex patterns for dynamic feature names
 SENSOR_TEMPLATES = [
@@ -660,7 +682,6 @@ def _get_auto_discovery_description(feature) -> SensorEntityDescription:
         case "kilowattHour":
             device_class = SensorDeviceClass.ENERGY
             native_unit = UnitOfEnergy.KILO_WATT_HOUR
-            state_class = SensorStateClass.TOTAL_INCREASING
         case "watt":
             device_class = SensorDeviceClass.POWER
             native_unit = UnitOfPower.WATT
@@ -668,7 +689,6 @@ def _get_auto_discovery_description(feature) -> SensorEntityDescription:
         case "wattHour":
             device_class = SensorDeviceClass.ENERGY
             native_unit = UnitOfEnergy.WATT_HOUR
-            state_class = SensorStateClass.TOTAL_INCREASING
         case "ampere":
             device_class = SensorDeviceClass.CURRENT
             native_unit = UnitOfElectricCurrent.AMPERE
@@ -679,8 +699,18 @@ def _get_auto_discovery_description(feature) -> SensorEntityDescription:
             native_unit = "L/h"
             state_class = SensorStateClass.MEASUREMENT
 
+    if (
+        device_class is SensorDeviceClass.ENERGY
+        and feature.name in AUTO_DISCOVERED_TOTAL_INCREASING_ENERGY_FEATURES
+    ):
+        state_class = SensorStateClass.TOTAL_INCREASING
+
     # Fallback for generic numbers
-    if state_class is None and isinstance(feature.value, (int, float)):
+    if (
+        device_class is None
+        and state_class is None
+        and isinstance(feature.value, (int, float))
+    ):
         state_class = SensorStateClass.MEASUREMENT
 
     return SensorEntityDescription(

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -1,14 +1,81 @@
 """Tests for the Viessmann Heat sensor platform."""
 
+import dataclasses
 from unittest.mock import MagicMock, patch
 
 import pytest
+from homeassistant.components.sensor import SensorStateClass
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 from vi_api_client import Device, Feature
+from vi_api_client.mock_client import MockViClient
 
-from custom_components.vi_climate_devices.const import DOMAIN
+from custom_components.vi_climate_devices.const import DOMAIN, IGNORED_FEATURES
+from custom_components.vi_climate_devices.sensor import SENSOR_TYPES
+from custom_components.vi_climate_devices.utils import is_feature_ignored
+
+FIXTURE_NAMES = MockViClient.get_available_mock_devices()
+
+AUTO_DISCOVERED_TOTAL_INCREASING_ENERGY_FEATURES = frozenset(
+    {
+        "ess.transfer.charge.cumulated.currentDay",
+        "ess.transfer.charge.cumulated.currentWeek",
+        "ess.transfer.charge.cumulated.currentMonth",
+        "ess.transfer.charge.cumulated.currentYear",
+        "ess.transfer.charge.cumulated.lifeCycle",
+        "ess.transfer.discharge.cumulated.currentDay",
+        "ess.transfer.discharge.cumulated.currentWeek",
+        "ess.transfer.discharge.cumulated.currentMonth",
+        "ess.transfer.discharge.cumulated.currentYear",
+        "ess.transfer.discharge.cumulated.lifeCycle",
+        "photovoltaic.production.cumulated.currentDay",
+        "photovoltaic.production.cumulated.currentWeek",
+        "photovoltaic.production.cumulated.currentMonth",
+        "photovoltaic.production.cumulated.currentYear",
+        "photovoltaic.production.cumulated.lifeCycle",
+        "pcc.transfer.consumption.total",
+        "pcc.transfer.feedIn.total",
+    }
+)
+
+AUTO_DISCOVERED_NON_CUMULATIVE_ENERGY_FEATURES = frozenset(
+    {
+        "ess.battery.usedAverage.averageUsableSystemEnergy",
+        "ess.battery.usedAverage.usableEnergyModuleOne",
+        "ess.battery.usedAverage.usableEnergyModuleTwo",
+        "ess.battery.usedAverage.usableEnergyModuleThree",
+        "ess.battery.usedAverage.usableEnergyModuleFour",
+        "ess.battery.usedAverage.usableEnergyModuleFive",
+        "ess.battery.usedAverage.usableEnergyModuleSix",
+        "heating.compressors.0.heat.production.cooling.week",
+        "heating.compressors.0.heat.production.dhw.week",
+        "heating.compressors.0.heat.production.heating.week",
+        "heating.compressors.0.power.consumption.dhw.week",
+        "heating.compressors.0.power.consumption.heating.week",
+    }
+)
+
+EXPECTED_AUTO_DISCOVERED_ENERGY_FEATURES = {
+    "Vitocal200S": frozenset(),
+    "Vitocal222S": frozenset(),
+    "Vitocal250A": frozenset(),
+    "Vitocal333G-with-Vitovent300F": frozenset(
+        feature_name
+        for feature_name in AUTO_DISCOVERED_NON_CUMULATIVE_ENERGY_FEATURES
+        if feature_name.startswith("heating.")
+    ),
+    "Vitocharge03": (
+        AUTO_DISCOVERED_TOTAL_INCREASING_ENERGY_FEATURES
+        | frozenset(
+            feature_name
+            for feature_name in AUTO_DISCOVERED_NON_CUMULATIVE_ENERGY_FEATURES
+            if feature_name.startswith("ess.")
+        )
+    ),
+    "Vitodens200W": frozenset(),
+    "Vitopure350": frozenset(),
+}
 
 
 async def _setup_integration(hass: HomeAssistant, mock_client):
@@ -224,12 +291,18 @@ async def test_auto_discovery_unit_mapping(hass: HomeAssistant, mock_client):
         assert entry_energy is not None
         assert entry_energy.disabled_by is None
         assert entry_energy.original_device_class == "energy"
+        energy_state = hass.states.get(entry_energy.entity_id)
+        assert energy_state is not None
+        assert "state_class" not in energy_state.attributes
 
         # Assert: Check WattHour Mapping
         entry_wh = registry.async_get("sensor.mockdevice_test_unknown_watthour")
         assert entry_wh is not None
         assert entry_wh.original_device_class == "energy"
         assert entry_wh.unit_of_measurement == "Wh"
+        watt_hour_state = hass.states.get(entry_wh.entity_id)
+        assert watt_hour_state is not None
+        assert "state_class" not in watt_hour_state.attributes
 
         # Assert: Check Ampere Mapping
         entry_amp = registry.async_get("sensor.mockdevice_test_unknown_ampere")
@@ -247,6 +320,111 @@ async def test_auto_discovery_unit_mapping(hass: HomeAssistant, mock_client):
         entry = hass.config_entries.async_entries(DOMAIN)[0]
         await hass.config_entries.async_unload(entry.entry_id)
         await hass.async_block_till_done()
+
+
+@pytest.mark.asyncio
+async def test_decreasing_unknown_energy_is_not_a_counter(
+    hass: HomeAssistant, mock_client
+):
+    """Test a decreasing unknown energy value stays non-cumulative."""
+    # Arrange: Build two snapshots whose unknown energy value decreases.
+    feature = Feature(
+        name="test.unknown.energy",
+        value=100.0,
+        is_enabled=True,
+        is_ready=True,
+        unit="kilowattHour",
+    )
+    device = Device(
+        id="0",
+        gateway_serial="mock_gateway",
+        installation_id="123",
+        features=[feature],
+        model_id="MockDevice",
+        device_type="heating",
+        status="online",
+    )
+    decreased_device = dataclasses.replace(
+        device, features=[dataclasses.replace(feature, value=90.0)]
+    )
+
+    with (
+        patch.object(
+            mock_client, "get_full_installation_status", return_value=[device]
+        ),
+        patch.object(
+            mock_client, "update_device", return_value=device
+        ) as update_device,
+    ):
+        await _setup_integration(hass, mock_client)
+        registry = er.async_get(hass)
+        registry_entry = registry.async_get("sensor.mockdevice_test_unknown_energy")
+        assert registry_entry is not None
+
+        # Act: Refresh after the absolute energy value decreases.
+        update_device.return_value = decreased_device
+        entry = hass.config_entries.async_entries(DOMAIN)[0]
+        await entry.runtime_data.async_request_refresh()
+        await hass.async_block_till_done()
+
+        # Assert: The new value is exposed without resettable-counter semantics.
+        state = hass.states.get(registry_entry.entity_id)
+        assert state is not None
+        assert state.state == "90.0"
+        assert "state_class" not in state.attributes
+
+        await hass.config_entries.async_unload(entry.entry_id)
+        await hass.async_block_till_done()
+
+
+@pytest.mark.parametrize("device_name", FIXTURE_NAMES)
+@pytest.mark.asyncio
+async def test_fixture_auto_discovered_energy_state_classes(
+    hass: HomeAssistant, device_name: str
+):
+    """Test every fixture's auto-discovered energy sensor classification."""
+    # Arrange: Load every feature from the selected real device fixture.
+    mock_client = MockViClient(device_name=device_name, auth=None)
+    installations = await mock_client.get_installations()
+    devices = await mock_client.get_full_installation_status(
+        installations[0].id, only_enabled=False
+    )
+    expected_feature_names = EXPECTED_AUTO_DISCOVERED_ENERGY_FEATURES[device_name]
+    fixture_features = {
+        feature.name: (device, feature)
+        for device in devices
+        for feature in device.features
+        if feature.unit in {"kilowattHour", "wattHour"}
+        and feature.name not in SENSOR_TYPES
+        and not is_feature_ignored(feature.name, IGNORED_FEATURES)
+    }
+
+    # Act: Discover the fixture through the Home Assistant integration.
+    await _setup_integration(hass, mock_client)
+    registry = er.async_get(hass)
+
+    # Assert: The audit stays exhaustive as fixtures gain energy properties.
+    assert fixture_features.keys() == expected_feature_names
+    for feature_name, (device, feature) in fixture_features.items():
+        unique_id = f"{device.gateway_serial}-{device.id}-{feature_name}"
+        entity_id = registry.async_get_entity_id("sensor", DOMAIN, unique_id)
+        assert entity_id is not None
+        state = hass.states.get(entity_id)
+        assert state is not None
+        assert state.attributes["device_class"] == "energy"
+        assert state.attributes["unit_of_measurement"] == (
+            "kWh" if feature.unit == "kilowattHour" else "Wh"
+        )
+        expected_state_class = (
+            SensorStateClass.TOTAL_INCREASING
+            if feature_name in AUTO_DISCOVERED_TOTAL_INCREASING_ENERGY_FEATURES
+            else None
+        )
+        assert state.attributes.get("state_class") == expected_state_class
+
+    entry = hass.config_entries.async_entries(DOMAIN)[0]
+    await hass.config_entries.async_unload(entry.entry_id)
+    await hass.async_block_till_done()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- stop inferring `TOTAL_INCREASING` from Wh/kWh units alone
- retain cumulative statistics for 17 verified Vitocharge energy counters
- keep battery capacities, unknown energy values, and unverified weekly aggregates non-cumulative
- audit the classification of every auto-discovered energy sensor across all seven available fixtures

## Testing

- `python scripts/quality_check.py`
- 121 tests passed
- Ruff, formatting, Pyright, and snapshot checks passed

Closes #129
